### PR TITLE
Fix mingw32 building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ EMCCFLAGS=-O2 -s EXPORTED_FUNCTIONS="['_sdb_querys','_sdb_new0']"
 sdb.js: src/sdb-version.h
 	cd src ; emcc ${EMCCFLAGS} -I. -o ../sdb.js ${CFILES}
 
-#json/api.c json/js0n.c json/json.c json/rangstr.c  
+#json/api.c json/js0n.c json/json.c json/rangstr.c
 
 clean:
 	rm -f src/sdb-version.h

--- a/config.mk
+++ b/config.mk
@@ -39,16 +39,23 @@ HAVE_VALA=$(shell valac --version 2> /dev/null)
 HOST_CC?=gcc
 RANLIB?=ranlib
 OS?=$(shell uname)
+OSTYPE?=$(shell uname -s)
 ARCH?=$(shell uname -m)
 
 ifeq (${OS},w32)
 WCP?=i386-mingw32
 CC=${WCP}-gcc
 AR?=${WCP}-ar
+ifeq (,$(findstring MINGW32,${OSTYPE}))
 CFLAGS_SHARED?=-fPIC
+endif
 EXEXT=.exe
 else
+ifeq (,$(findstring CYGWIN,${OSTYPE}))
+ifeq (,$(findstring MINGW32,${OSTYPE}))
 CFLAGS_SHARED?=-fPIC
+endif
+endif
 # -fvisibility=hidden
 AR?=ar
 CC?=gcc
@@ -63,15 +70,32 @@ SOEXT=dylib
 SOVER=dylib
 LDFLAGS+=-dynamic
 LDFLAGS_SHARED?=-fPIC -shared
- ifeq (${ARCH},i386)
-   #CC+=-arch i386 
-   CC+=-arch x86_64
- endif
+ifeq (${ARCH},i386)
+#CC+=-arch i386
+CC+=-arch x86_64
+endif
 else
+ifneq (,$(findstring CYGWIN,${OSTYPE}))
+CFLAGS+=-D__CYGWIN__=1
+SOEXT=dll
+SOVER=${SOEXT}
+LDFLAGS+=-shared
+LDFLAGS_SHARED?=-shared
+else
+ifneq (,$(findstring MINGW32,${OSTYPE}))
+CFLAGS+=-DMINGW32=1
+SOEXT=dll
+SOVER=${SOEXT}
+LDFLAGS+=-shared
+LDFLAGS_SHARED?=-shared
+else
+CFLAGS+=-fPIC
 SOVERSION=0
 SOEXT=so
 SOVER=${SOEXT}.${SDBVER}
 LDFLAGS_SHARED?=-fPIC -shared
+endif
+endif
 LDFLAGS_SHARED+=-Wl,-soname,libsdb.so.$(SOVERSION)
 endif
 


### PR DESCRIPTION
Improved cygwin and ming32 support, related to https://github.com/radare/radare2/issues/1099

Still this error though (while building radare2 on top of it, looks like not cygwin/ming32 related:

```
make static
make[4]: Entering directory `/d/Work/radare/radare2/shlr/sdb/src'
make libsdb.a
make[5]: Entering directory `/d/Work/radare/radare2/shlr/sdb/src'
make[5]: `libsdb.a' is up to date.
make[5]: Leaving directory `/d/Work/radare/radare2/shlr/sdb/src'
make[4]: Leaving directory `/d/Work/radare/radare2/shlr/sdb/src'
make shared
make[4]: Entering directory `/d/Work/radare/radare2/shlr/sdb/src'
make libsdb.dll
make[5]: Entering directory `/d/Work/radare/radare2/shlr/sdb/src'
gcc -c  -g  -o cdb._o cdb.c
gcc -c  -g  -o buffer._o buffer.c
gcc -c  -g  -o cdb_make._o cdb_make.c
gcc -c  -g  -o ls._o ls.c
gcc -c  -g  -o ht._o ht.c
gcc -c  -g  -o sdb._o sdb.c
gcc -c  -g  -o num._o num.c
gcc -c  -g  -o base64._o base64.c
gcc -c  -g  -o json._o json.c
gcc -c  -g  -o ns._o ns.c
gcc -c  -g  -o lock._o lock.c
gcc -c  -g  -o util._o util.c
gcc -c  -g  -o disk._o disk.c
gcc -c  -g  -o query._o query.c
gcc -c  -g  -o array._o array.c
gcc -c  -g  -o fmt._o fmt.c
gcc -shared -shared -Wl,-soname,libsdb.so. -o libsdb.dll cdb._o buffer._o cdb_ma
e._o ls._o ht._o sdb._o num._o base64._o json._o ns._o lock._o util._o disk._o
query._o array._o fmt._o
make[5]: Leaving directory `/d/Work/radare/radare2/shlr/sdb/src'
make[4]: Leaving directory `/d/Work/radare/radare2/shlr/sdb/src'
make[3]: Leaving directory `/d/Work/radare/radare2/shlr/sdb/src'
make -C memcache
make[3]: Entering directory `/d/Work/radare/radare2/shlr/sdb/memcache'
gcc -c  -g  -o cmds.o cmds.c
cmds.c:3:17: fatal error: sdb.h: No such file or directory
compilation terminated.
make[3]: *** [cmds.o] Error 1
make[3]: Leaving directory `/d/Work/radare/radare2/shlr/sdb/memcache'
make[2]: *** [all] Error 2
make[2]: Leaving directory `/d/Work/radare/radare2/shlr/sdb'
make[1]: *** [sdb/sdb] Error 2
make[1]: Leaving directory `/d/Work/radare/radare2/shlr'
make: *** [all] Error 2
```
