### PR TITLE
Strip UTF8 BOM when creating db

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -265,9 +265,13 @@ static int createdb(const char *f, const char **args, int nargs) {
 	insertkeys (s, args, nargs, '=');
 	sdb_config (s, options);
 	for (; (line = stdin_slurp (NULL));) {
-		if ((eq = strchr (line, '='))) {
+		size_t off = 0;
+		if (line[0] == '\xef' && line[1] == '\xbb' && line[2] == '\xbf') {
+			off = 3;
+		}
+		if ((eq = strchr (line + off, '='))) {
 			*eq++ = 0;
-			sdb_disk_insert (s, line, eq);
+			sdb_disk_insert (s, line + off, eq);
 		}
 		free (line);
 	}


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr prevents the following:

![BOM_in_sdb_with_oval](https://user-images.githubusercontent.com/12002672/86370930-e3301080-bcb2-11ea-80cf-237585bd4c36.png)

i.e. a UTF8 BOM in an sdb, due to a UTF8 BOM that materialized in sdb.exe's input.

For this particular case, I'm not entirely sure how it materialized -- current hypothesis is that a combination of PowerShell's Get-Content + https://superuser.com/questions/269818/change-default-code-page-of-windows-console-to-utf-8/1435645#1435645 is the cause.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Travis is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
