### PR TITLE
Add support for `local` meson option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,12 +64,19 @@ libsdb_sources = [
 ]
 
 sdb_inc = include_directories(['.', 'src'])
+rpath_lib = ''
+rpath_exe = ''
+if get_option('local') and get_option('default_library') == 'shared'
+  rpath_lib = '$ORIGIN'
+  rpath_exe = '$ORIGIN/../' + get_option('libdir')
+endif
 
 libsdb = both_libraries('sdb', libsdb_sources,
   include_directories: sdb_inc,
   implicit_include_directories: false,
   soversion: sdb_libversion,
-  install: not meson.is_subproject()
+  install: not meson.is_subproject(),
+  install_rpath: rpath_lib
 )
 
 sdb_dep = declare_dependency(
@@ -107,6 +114,7 @@ sdb_exe = executable('sdb', 'src/main.c',
   include_directories: sdb_inc,
   link_with: [link_with],
   install: not meson.is_subproject(),
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('enable_tests', type: 'boolean', value: true, description: 'Build unit tests in test/unit')
+option('local', type: 'boolean', value: false, description: 'Adds support for local/side-by-side installation (sets rpath if needed)')


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Similar to radare2, it allows to install sdb in a local path and set rpath so that you don't have to mess with LD_LIBRARY_PATH & co.
