### PR TITLE
Fix OOB write in text parsing

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -362,7 +362,7 @@ SDB_API bool sdb_text_load_buf(Sdb *s, char *buf, size_t sz) {
 	while (ctx.pos < ctx.bufsz) {
 		load_process_single_char (&ctx);
 	}
-	if (ctx.line_begin < ctx.bufsz) {
+	if (ctx.line_begin < ctx.bufsz && ctx.state != STATE_NEWLINE) {
 		// load_flush_line needs ctx.buf[ctx.pos] to be allocated!
 		// so we need room for one additional byte after the buffer.
 		size_t linesz = ctx.bufsz - ctx.line_begin;

--- a/src/text.c
+++ b/src/text.c
@@ -382,6 +382,7 @@ SDB_API bool sdb_text_load_buf(Sdb *s, char *buf, size_t sz) {
 			ctx.line_begin = 0;
 			load_flush_line (&ctx);
 			free (linebuf);
+			ctx.buf = NULL;
 		} else {
 			ret = false;
 		}

--- a/src/text.c
+++ b/src/text.c
@@ -224,7 +224,7 @@ typedef struct {
 // to be called at the end of a line.
 // save all the data processed from the line into the database.
 // assumes that the ctx->buf is allocated until ctx->buf[ctx->pos] inclusive!
-static void load_flush_line(LoadCtx *ctx) {
+static void load_process_line(LoadCtx *ctx) {
 	ctx->unescape = false;
 	// finish up the line
 	ctx->buf[ctx->pos - ctx->shift] = '\0';
@@ -281,7 +281,7 @@ static inline char unescape_raw_char (char c) {
 static void load_process_single_char(LoadCtx *ctx) {
 	char c = ctx->buf[ctx->pos];
 	if (c == '\n' || c == '\r') {
-		load_flush_line (ctx);
+		load_process_line (ctx);
 		ctx->pos++;
 		return;
 	}
@@ -327,7 +327,7 @@ static void load_process_single_char(LoadCtx *ctx) {
 }
 
 static bool load_process_final_line(LoadCtx *ctx) {
-	// load_flush_line needs ctx.buf[ctx.pos] to be allocated!
+	// load_process_line needs ctx.buf[ctx.pos] to be allocated!
 	// so we need room for one additional byte after the buffer.
 	size_t linesz = ctx->bufsz - ctx->line_begin;
 	char *linebuf = malloc (linesz + 1);
@@ -346,7 +346,7 @@ static bool load_process_final_line(LoadCtx *ctx) {
 		it->data = (void *)((size_t)token_off_tmp - ctx->line_begin);
 	}
 	ctx->line_begin = 0;
-	load_flush_line (ctx);
+	load_process_line (ctx);
 	free (linebuf);
 	ctx->buf = NULL;
 	return true;


### PR DESCRIPTION
This happens because `load_flush_line()` will write a zero-byte just after the line. Most of the time, this just overwrites the `\n` but at the very end of the file, it writes one byte after the allocated buffer. With mmap this usually stays undetected because the whole page is allocated, but with mmap disabled and asan it shows even in the current tests.
There would be different ways to fix this:
* Always pass a 1-byte bigger buffer to `sdb_text_load_buf()`: If done directly like this, a user of the function would have to be aware of that and it goes against everything we are used to when we have an additional size argument. Alternatively the string may always be forced to be zero-terminated and the size removed, but that would imply a lot of additional checks and issues, or a strlen over the possibly huge buffer so this isn't really a nice solution either
* Make `load_flush_line()` not write this zero-byte there: In this case, it would have to do a strdup in every single line to feed the value into `sdb_set()`, which would be a huge additional overhead.
* Before parsing the last line, strdup the line with size+1 and let `load_flush_line()` work on that copy. This is what I did here. It's a bit ugly but the solution with the least problems and it is covered well by tests.

```
[florian@florian-desktop sdb]$ build/test/unit/test_sdb
test_sdb_namespace OK
test_sdb_foreach_delete OK
test_sdb_list_delete OK
test_sdb_delete_none OK
test_sdb_delete_alot OK
test_sdb_milset OK
test_sdb_milset_random OK
test_sdb_list_big OK
test_sdb_foreach_filter OK
test_sdb_copy OK
test_sdb_text_save_simple OK
test_sdb_text_save_simple_unsorted OK
test_sdb_text_load_simple OK
test_sdb_text_save OK
test_sdb_text_load OK
test_sdb_text_load_bad_nl OK
test_sdb_text_load_broken OK
=================================================================
==54444==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60e0000001b9 at pc 0x56104b5fb3bf bp 0x7ffd98007da0 sp 0x7ffd98007d90
WRITE of size 1 at 0x60e0000001b9 thread T0
    #0 0x56104b5fb3be in load_flush_line ../src/text.c:229
    #1 0x56104b5fc721 in sdb_text_load_buf ../src/text.c:364
    #2 0x56104b5fca38 in sdb_text_load ../src/text.c:394
    #3 0x56104b5e63f2 in test_sdb_text_load_file ../test/unit/test_sdb.c:471
    #4 0x56104b5e6b8e in all_tests ../test/unit/test_sdb.c:502
    #5 0x56104b5e6be3 in main ../test/unit/test_sdb.c:507
    #6 0x7fbb5b5d6151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)
    #7 0x56104b5e147d in _start (/home/florian/dev/sdb/build/test/unit/test_sdb+0x647d)

0x60e0000001b9 is located 0 bytes to the right of 153-byte region [0x60e000000120,0x60e0000001b9)
allocated by thread T0 here:
    #0 0x7fbb5b829639 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x56104b5fc941 in sdb_text_load ../src/text.c:385
    #2 0x56104b5e63f2 in test_sdb_text_load_file ../test/unit/test_sdb.c:471
    #3 0x56104b5e6b8e in all_tests ../test/unit/test_sdb.c:502
    #4 0x56104b5e6be3 in main ../test/unit/test_sdb.c:507
    #5 0x7fbb5b5d6151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)

SUMMARY: AddressSanitizer: heap-buffer-overflow ../src/text.c:229 in load_flush_line
Shadow bytes around the buggy address:
  0x0c1c7fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1c7fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1c7fff8000: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c1c7fff8010: fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c1c7fff8020: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c1c7fff8030: 00 00 00 00 00 00 00[01]fa fa fa fa fa fa fa fa
  0x0c1c7fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff8060: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff8070: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff8080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==54444==ABORTING
```