### PR TITLE
Added missing null check

### DIFF
--- a/src/ht_inc.c
+++ b/src/ht_inc.c
@@ -302,7 +302,9 @@ SDB_API HT_(Kv)* Ht_(find_kv)(HtName_(Ht)* ht, const KEY_TYPE key, bool* found) 
 		*found = false;
 	}
 	if (!ht) {
-		*found = false;
+		if (found) {
+			*found = false;
+		}
 		return NULL;
 	}
 


### PR DESCRIPTION
**Detailed description**

Added a missing null check in ht_(find_kv) in ht_inc.c
While fuzzing I caused this nullpointer dereference and while looking for the root cause I realized that a check is missing.

**Test plan**

I really just added an if to avoid a null pointer dereference.

**Closing issues**

None