### PR TITLE
Remove TLS and make sdb thread-safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ ASANOPTS=address undefined signed-integer-overflow leak
 CFLAGS_ASAN=$(addprefix -fsanitize=,$(ASANOPTS))
 MKDIR=mkdir
 
-# CFLAGS+=-DSDB_WANT_THREADS=1
-
 all: pkgconfig src/sdb_version.h
 	${MAKE} -C src
 ifeq ($(BUILD_MEMCACHE),1)

--- a/src/fmt.c
+++ b/src/fmt.c
@@ -20,23 +20,6 @@
 	} \
 }
 
-SDB_API char *sdb_fmt(const char *fmt, ...) {
-#define KL 256
-#define KN 16
-	static __thread char Key[KN][KL];
-	static __thread int n = 0;
-	va_list ap;
-	va_start (ap, fmt);
-	n = (n + 1) % KN;
-	if (fmt) {
-		*Key[n] = 0;
-		vsnprintf (Key[n], KL - 1, fmt, ap);
-		Key[n][KL - 1] = 0;
-	}
-	va_end (ap);
-	return Key[n];
-}
-
 SDB_API char *sdb_fmt_tostr(void *p, const char *fmt) {
 	char buf[128], *e_str, *out = NULL;
 	int n, len = 0;

--- a/src/json/js0n.c
+++ b/src/json/js0n.c
@@ -31,7 +31,7 @@ int sdb_js0n(const ut8 *js, RangstrType len, RangstrType *out) {
 	ut32 prev = 0;
 	const ut8 *cur, *end;
 	int depth = 0, utf8_remain = 0;
-	static void *gostruct[] = {
+	const static void *const gostruct[] = {
 		[0 ... 255] = &&l_bad,
 		['\t'] = &&l_loop, [' '] = &&l_loop, ['\r'] = &&l_loop, ['\n'] = &&l_loop,
 		['"'] = &&l_qup,
@@ -46,7 +46,7 @@ int sdb_js0n(const ut8 *js, RangstrType len, RangstrType *out) {
 		['t'] = &&l_bare, ['f'] = &&l_bare, ['n'] = &&l_bare // true, false, null
 #endif
 	};
-	static void *gobare[] = {
+	const static void *const gobare[] = {
 		[0 ... 31] = &&l_bad,
 		[32 ... 126] = &&l_loop, // could be more pedantic/validation-checking
 		['\t'] = &&l_unbare, [' '] = &&l_unbare, ['\r'] = &&l_unbare, ['\n'] = &&l_unbare,
@@ -54,7 +54,7 @@ int sdb_js0n(const ut8 *js, RangstrType len, RangstrType *out) {
 		[127 ... 255] = &&l_bad
 	};
 #if HAVE_RAWSTR
-	static void *gorawstr[] = {
+	const static void *const gorawstr[] = {
 		[0 ... 31] = &&l_bad, [127] = &&l_bad,
 		[32 ... 126] = &&l_loop,
 		['\\'] = &&l_esc, [':'] = &&l_qdown,
@@ -65,7 +65,7 @@ int sdb_js0n(const ut8 *js, RangstrType len, RangstrType *out) {
 		[248 ... 255] = &&l_bad
 	};
 #endif
-	static void *gostring[] = {
+	const static void *const gostring[] = {
 		[0 ... 31] = &&l_bad, [127] = &&l_bad,
 		[32 ... 126] = &&l_loop,
 		['\\'] = &&l_esc, ['"'] = &&l_qdown,
@@ -75,17 +75,17 @@ int sdb_js0n(const ut8 *js, RangstrType len, RangstrType *out) {
 		[240 ... 247] = &&l_utf8_4,
 		[248 ... 255] = &&l_bad
 	};
-	static void *goutf8_continue[] = {
+	const static void *const goutf8_continue[] = {
 		[0 ... 127] = &&l_bad,
 		[128 ... 191] = &&l_utf_continue,
 		[192 ... 255] = &&l_bad
 	};
-	static void *goesc[] = {
+	const static void *const goesc[] = {
 		[0 ... 255] = &&l_bad,
 		['"'] = &&l_unesc, ['\\'] = &&l_unesc, ['/'] = &&l_unesc, ['b'] = &&l_unesc,
 		['f'] = &&l_unesc, ['n'] = &&l_unesc, ['r'] = &&l_unesc, ['t'] = &&l_unesc, ['u'] = &&l_unesc
 	};
-	static void **go = gostruct;
+	const void *const *go = gostruct;
 	
 #if 0 
 printf ("                 gostrct= %p\n", gostruct);

--- a/src/lock.c
+++ b/src/lock.c
@@ -8,19 +8,18 @@
 static int getpid(void) { return 0; }
 #endif
 
-SDB_API const char *sdb_lock_file(const char *f) {
-	static char buf[128];
+SDB_API bool sdb_lock_file(const char *f, char *buf, size_t buf_size) {
 	size_t len;
-	if (!f || !*f) {
-		return NULL;
+	if (!f || !*f || !buf || !buf_size) {
+		return false;
 	}
 	len = strlen (f);
-	if (len + 10 > sizeof buf) {
-		return NULL;
+	if (len + 10 > buf_size) {
+		return false;
 	}
 	memcpy (buf, f, len);
 	strcpy (buf + len, ".lock");
-	return buf;
+	return true;
 }
 
 SDB_API bool sdb_lock(const char *s) {

--- a/src/query.c
+++ b/src/query.c
@@ -207,12 +207,14 @@ repeat:
 	quot = NULL;
 	json = NULL;
 	if (*p == '#') {
+		char buffer[16];
 		p++;
 		next = strchr (p, ';');
 		if (next) {
 			*next = 0;
 		}
-		out_concat (sdb_fmt ("0x%08x\n", sdb_hash (p)));
+		(void)snprintf (buffer, sizeof (buffer), "0x%08x\n", sdb_hash (p));
+		strbuf_append (out, buffer, 1);
 		if (next) {
 			*next = ';';
 		}

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -31,20 +31,11 @@ static inline SdbKv *next_kv(HtPP *ht, SdbKv *kv) {
 		     (j) < (bt)->count;					\
 		     (j) = (count) == (ht)->count? j + 1: j, (kv) = (count) == (ht)->count? next_kv (ht, kv): kv, (count) = (ht)->count)
 
-static inline int nextcas(void) {
-	static TLSVAR ut32 cas = 1;
-	if (!cas) {
-		cas++;
+static inline int nextcas(SdbKv const *kv) {
+	if (!kv->cas) {
+		return 1;
 	}
-	return cas++;
-}
-
-static TLSVAR SdbHook global_hook = NULL;
-static TLSVAR void* global_user = NULL;
-
-SDB_API void sdb_global_hook(SdbHook hook, void *user) {
-	global_hook = hook;
-	global_user = user;
+	return kv->cas + 1;
 }
 
 // TODO: use mmap instead of read.. much faster!
@@ -65,6 +56,8 @@ SDB_API Sdb* sdb_new(const char *path, const char *name, int lock) {
 		path = NULL;
 	}
 	if (name && *name && strcmp (name, "-")) {
+		char buf[SDB_MAX_PATH];
+
 		if (path && *path) {
 			size_t plen = strlen (path);
 			size_t nlen = strlen (name);
@@ -82,12 +75,18 @@ SDB_API Sdb* sdb_new(const char *path, const char *name, int lock) {
 		}
 		switch (lock) {
 		case 1:
-			if (!sdb_lock (sdb_lock_file (s->dir))) {
+			if (!sdb_lock_file (s->dir, buf, sizeof (buf))) {
+				goto fail;
+			}
+			if (!sdb_lock (buf)) {
 				goto fail;
 			}
 			break;
 		case 2:
-			if (!sdb_lock_wait (sdb_lock_file (s->dir))) {
+			if (!sdb_lock_file (s->dir, buf, sizeof (buf))) {
+				goto fail;
+			}
+			if (!sdb_lock_wait (buf)) {
 				goto fail;
 			}
 			break;
@@ -114,10 +113,6 @@ SDB_API Sdb* sdb_new(const char *path, const char *name, int lock) {
 		goto fail;
 	}
 	s->lock = lock;
-	// if open fails ignore
-	if (global_hook) {
-		sdb_hook (s, global_hook, global_user);
-	}
 	cdb_init (&s->db, s->fd);
 	return s;
 fail:
@@ -134,13 +129,16 @@ fail:
 
 // XXX: this is wrong. stuff not stored in memory is lost
 SDB_API void sdb_file(Sdb* s, const char *dir) {
+	char buf[SDB_MAX_PATH];
 	if (s->lock) {
-		sdb_unlock (sdb_lock_file (s->dir));
+		sdb_lock_file (s->dir, buf, sizeof (buf));
+		sdb_unlock (buf);
 	}
 	free (s->dir);
 	s->dir = (dir && *dir)? strdup (dir): NULL;
 	if (s->lock) {
-		sdb_lock (sdb_lock_file (s->dir));
+		sdb_lock_file (s->dir, buf, sizeof (buf));
+		sdb_lock (buf);
 	}
 }
 
@@ -185,13 +183,15 @@ SDB_API int sdb_count(Sdb *s) {
 }
 
 static void sdb_fini(Sdb* s, bool donull) {
+	char buf[SDB_MAX_PATH];
 	if (!s) {
 		return;
 	}
 	sdb_hook_free (s);
 	cdb_free (&s->db);
 	if (s->lock) {
-		sdb_unlock (sdb_lock_file (s->dir));
+		sdb_lock_file (s->dir, buf, sizeof (buf));
+		sdb_unlock (buf);
 	}
 	sdb_ns_free (s);
 	s->refs = 0;
@@ -558,7 +558,7 @@ SDB_API SdbKv* sdbkv_new2(const char *k, int kl, const char *v, int vl) {
 		kv->base.value = NULL;
 		kv->base.value_len = 0;
 	}
-	kv->cas = nextcas ();
+	kv->cas = nextcas (kv);
 	kv->expire = 0LL;
 	return kv;
 }
@@ -611,7 +611,7 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, bool owned, ut3
 				sdb_hook_call (s, key, val);
 				return kv->cas;
 			}
-			kv->cas = cas = nextcas ();
+			kv->cas = cas = nextcas (kv);
 			if (owned) {
 				kv->base.value_len = vlen;
 				free (kv->base.value);
@@ -642,7 +642,7 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, bool owned, ut3
 		kv = sdbkv_new2 (key, klen, val, vlen);
 	}
 	if (kv) {
-		ut32 cas = kv->cas = nextcas ();
+		ut32 cas = kv->cas = nextcas (kv);
 		sdb_ht_insert_kvp (s->ht, kv, true /*update*/);
 		free (kv);
 		sdb_hook_call (s, key, val);

--- a/src/sdb.h
+++ b/src/sdb.h
@@ -18,13 +18,6 @@ extern "C" {
 #include "cdb_make.h"
 #include "sdb_version.h"
 
-#if SDB_WANT_THREADS
-#include <threads.h>
-#define TLSVAR __thread
-#else
-#define TLSVAR
-#endif
-
 /* Key value sizes */
 #define SDB_MIN_VALUE 1
 #define SDB_MAX_VALUE 0xffffff
@@ -255,11 +248,10 @@ SDB_API bool sdb_journal_unlink(Sdb *s);
 /* numeric */
 SDB_API char *sdb_itoa(ut64 n, char *s, int base);
 SDB_API ut64  sdb_atoi(const char *s);
-SDB_API const char *sdb_itoca(ut64 n);
 
 /* locking */
 SDB_API bool sdb_lock(const char *s);
-SDB_API const char *sdb_lock_file(const char *f);
+SDB_API bool sdb_lock_file(const char *f, char *buf, size_t buf_size);
 SDB_API void sdb_unlock(const char *s);
 SDB_API bool sdb_unlink(Sdb* s);
 SDB_API int sdb_lock_wait(const char *s UNUSED);
@@ -375,7 +367,6 @@ SDB_API char *sdb_array_pop_tail(Sdb *s, const char *key, ut32 *cas);
 
 typedef void (*SdbHook)(Sdb *s, void *user, const char *k, const char *v);
 
-SDB_API void sdb_global_hook(SdbHook hook, void *user);
 SDB_API bool sdb_hook(Sdb* s, SdbHook cb, void* user);
 SDB_API bool sdb_unhook(Sdb* s, SdbHook h);
 SDB_API int sdb_hook_call(Sdb *s, const char *k, const char *v);
@@ -396,7 +387,6 @@ SDB_API void sdb_encode_raw(char *bout, const ut8 *bin, int len);
 SDB_API int sdb_decode_raw(ut8 *bout, const char *bin, int len);
 
 // binfmt
-SDB_API char *sdb_fmt(const char *fmt, ...) SDB_PRINTF_CHECK(1, 2);
 SDB_API int sdb_fmt_init(void *p, const char *fmt);
 SDB_API void sdb_fmt_free(void *p, const char *fmt);
 SDB_API int sdb_fmt_tobin(const char *_str, const char *fmt, void *stru);

--- a/src/util.c
+++ b/src/util.c
@@ -95,14 +95,10 @@ SDB_API ut8 sdb_hash_byte(const char *s) {
 	return h[0] ^ h[1] ^ h[2] ^ h[3];
 }
 
-SDB_API const char *sdb_itoca(ut64 n) {
-	return sdb_itoa (n, sdb_fmt (NULL), 16);
-}
-
 // assert (sizeof (s)>64)
 // if s is null, the returned pointer must be freed!!
 SDB_API char *sdb_itoa(ut64 n, char *os, int base) {
-	static const char* lookup = "0123456789abcdef";
+	static const char *const lookup = "0123456789abcdef";
 	char tmpbuf[64], *s = NULL;
 	const int imax = 62;
 	int i = imax, copy_string = 1;

--- a/test/hook2.c
+++ b/test/hook2.c
@@ -5,13 +5,13 @@ void ptr(Sdb *s, void *user, const char *k, const char *v) {
 }
 
 int main() {
-	sdb_global_hook (ptr, NULL);
-
 	Sdb *s = sdb_new (NULL, 0, 0);
+	sdb_hook (s, ptr, NULL);
 	sdb_set (s, "Hello", "World", 0);
 	sdb_free (s);
 
 	s = sdb_new (NULL, 0, 0);
+	sdb_hook (s, ptr, NULL);
 	sdb_set (s, "World", "Hello", 0);
 	sdb_free (s);
 	return 0;

--- a/test/unit/test_sdb.c
+++ b/test/unit/test_sdb.c
@@ -50,16 +50,12 @@ static inline int fakerand() {
 }
 
 static bool test_sdb_list_big(void) {
+	char buffer[256];
 	Sdb *db = sdb_new0 ();
 	int i;
-#if 0
-	// 6-7s
-	for (i = 0; i < 5000000; i++) {
-		sdb_num_set (db, sdb_fmt ("%d", fakerand()), i + 1, 0);
-	}
-#endif
 	for (i = 0; i < 500000; i++) {
-		sdb_num_set (db, sdb_fmt ("0x%x", fakerand()), i + 1, 0);
+		(void)snprintf (buffer, sizeof (buffer), "0x%x", fakerand ());
+		sdb_num_set (db, buffer, i + 1, 0);
 	}
 	ut64 now = sdb_now ();
 	SdbList *list = sdb_foreach_list (db, true);
@@ -89,14 +85,17 @@ bool test_sdb_delete_none(void) {
 
 bool test_sdb_delete_alot(void) {
 	Sdb *db = sdb_new (NULL, NULL, false);
+	char buffer[32];
 	const int count = 2048;
 	int i;
 
 	for (i = 0; i < count; i++) {
-		sdb_set (db, sdb_fmt ("key.%d", i), "bar", 0);
+		(void)snprintf (buffer, sizeof (buffer), "key.%d", i);
+		sdb_set (db, buffer, "bar", 0);
 	}
 	for (i = 0; i < count; i++) {
-		sdb_unset (db, sdb_fmt ("key.%d", i), 0);
+		(void)snprintf (buffer, sizeof (buffer), "key.%d", i);
+		sdb_unset (db, buffer, 0);
 	}
 	SdbList *list = sdb_foreach_list (db, false);
 	mu_assert_eq (ls_length (list), 0, "Unmatched rows");
@@ -125,11 +124,12 @@ static bool test_sdb_milset_random(void) {
 	int i = 0;
 	const int MAX = 19999999;
 	bool solved = true;
+	char buffer[256];
 	Sdb *s = sdb_new0 ();
 	sdb_set (s, "foo", "bar", 0);
 	for (i = 0; i < MAX ; i++) {
-		char *v = sdb_fmt ("bar%d", i);
-		if (!sdb_set (s, "foo", v, 0)) {
+		(void)snprintf (buffer, sizeof (buffer), "bar%d", i);
+		if (!sdb_set (s, "foo", buffer, 0)) {
 			solved = false;
 			break;
 		}


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

This makes sdb thread-safe without the need for TLS.

* Nuke sdb_fmt
* Mark goto tables as const
* Mark lookup table as const
* Move nextcas into SdbKv
* Remove global hook (cannot be used without TLS, but we want to avoid
  that)
* Fix lock path to not use a static buffer