### PR TITLE
Make sdb compilable as C++

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: build/*.exe
+  build-cxx:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Building Sdb
+      run: make xxx
+    - name: Testing gperf
+      run: make -C test
   build-asan:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ endif
 
 include wasi.mk
 
+x xxx cxx:
+	# $(MAKE) CC="gcc -x c++ -Wall -fpermissive"
+	$(MAKE) CC=g++ CFLAGS="-fPIC -x c++ -Wall -fpermissive"
+
+o xo xoxo ox:
+	g++ -o sdb src/*.c  -I src/
+
 wasi wasm: $(WASI_SDK)
 	${MAKE} src/sdb_version.h
 	CC=$(WASI_CC) CFLAGS="$(WASI_CFLAGS)" $(MAKE) CC=$(WASI_CC) -C src all WITHPIC=0
@@ -40,7 +47,7 @@ asantest:
 
 asan:
 	${MAKE} src/sdb_version.h
-	CC=gcc CFLAGS="$(CFLAGS_ASAN)" ${MAKE} -C src all
+	CC=gcc LDFLAGS="$(CFLAGS_ASAN)" CFLAGS="$(CFLAGS_ASAN)" ${MAKE} -C src all
 
 pkgconfig:
 	[ -d pkgconfig ] && ${MAKE} -C pkgconfig || true

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,7 @@ endif
 ifneq ($(SILENT),)
 	@echo LIB libsdb${SOVER}
 endif
-	$(CC) ${CFLAGS} ${LDFLAGS} $(LDFLAGS_SHARED) -o $@ ${SOBJ}
+	$(CC) ${LDFLAGS} $(LDFLAGS_SHARED) -o $@ ${SOBJ}
 
 bin_deps: sdb_version.h
 	$(MAKE) libsdb.a main.o
@@ -65,7 +65,7 @@ bin $(BIN): bin_deps
 ifneq ($(SILENT),)
 	@echo BIN ${BIN}
 endif
-	$(CC) ${CFLAGS} ${LDFLAGS} -o ${BIN} main.o ${OBJ}
+	$(CC) ${LDFLAGS} -o ${BIN} main.o ${OBJ}
 
 mrproper clean:
 	rm -rf ${OBJ} ${SOBJ} main.o libsdb.a a.out ${BIN} sdb.dSYM

--- a/src/array.c
+++ b/src/array.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2011-2018 - pancake */
+/* sdb - MIT - Copyright 2011-2022 - pancake */
 
 #include "sdb.h"
 #include <limits.h>
@@ -97,12 +97,12 @@ SDB_API char *sdb_array_get(Sdb *s, const char *key, int idx, ut32 *cas) {
 		idx = len - idx;
 	}
 	if (!idx) {
-		n = strchr (str, SDB_RS);
+		n = strchr ((char *)str, SDB_RS);
 		if (!n) {
 			return strdup (str);
 		}
 		len = n - str;
-		o = malloc (len + 1);
+		o = (char *)malloc (len + 1);
 		if (!o) {
 			return NULL;
 		}
@@ -111,16 +111,16 @@ SDB_API char *sdb_array_get(Sdb *s, const char *key, int idx, ut32 *cas) {
 		return o;
 	}
 	for (i = 0; i < idx; i++) {
-		n = strchr (p, SDB_RS);
+		n = strchr ((char *)p, SDB_RS);
 		if (!n) return NULL;
 		p = n + 1;
 	}
-	n = strchr (p, SDB_RS);
+	n = strchr ((char *)p, SDB_RS);
 	if (!n) {
 		return strdup (p);
 	}
 	len = n - p;
-	o = malloc (len + 1);
+	o = (char *)malloc (len + 1);
 	if (o) {
 		memcpy (o, p, len);
 		o[len] = 0;
@@ -157,7 +157,7 @@ SDB_API int sdb_array_insert(Sdb *s, const char *key, int idx, const char *val,
 	if (SZT_ADD_OVFCHK (lval, lstr_tmp) || SZT_ADD_OVFCHK (lval + lstr_tmp, 2)) {
 		return false;
 	}
-	x = malloc (lval + lstr_tmp + 2);
+	x = (char *)malloc (lval + lstr_tmp + 2);
 	if (!x) {
 		return false;
 	}
@@ -171,7 +171,7 @@ SDB_API int sdb_array_insert(Sdb *s, const char *key, int idx, const char *val,
 		x[lval] = SDB_RS;
 		memcpy (x + lval + 1, str, lstr + 1);
 	} else {
-		char *nstr = malloc (lstr + 1);
+		char *nstr = (char *)malloc (lstr + 1);
 		if (!nstr) {
 			free (x);
 			return false;
@@ -248,7 +248,7 @@ SDB_API int sdb_array_add_sorted(Sdb *s, const char *key, const char *val, ut32 
 	if (i > 1) {
 		qsort (vals, i, sizeof (ut64*), cstring_cmp);
 	}
-	nstr_p = nstr = malloc (lstr + lval + 3);
+	nstr_p = nstr = (char *)malloc (lstr + lval + 3);
 	if (!nstr) {
 		return 1;
 	}
@@ -321,7 +321,7 @@ SDB_API bool sdb_array_append(Sdb *s, const char *key, const char *val,
 	cas = kas;
 	if (str && *str && str_len > 0) {
 		int val_len = strlen (val);
-		char *newval = malloc (str_len + val_len + 2);
+		char *newval = (char *)malloc (str_len + val_len + 2);
 		if (!newval) {
 			return false;
 		}
@@ -359,7 +359,7 @@ SDB_API int sdb_array_set(Sdb *s, const char *key, int idx, const char *val,
 	lval = strlen (val);
 	if (idx > len) {
 		int ret, i, ilen = idx-len;
-		char *newkey = malloc (ilen + lval + 1);
+		char *newkey = (char *)malloc (ilen + lval + 1);
 		if (!newkey) {
 			return 0;
 		}
@@ -375,7 +375,7 @@ SDB_API int sdb_array_set(Sdb *s, const char *key, int idx, const char *val,
 	ptr = (char*)Aindexof (str, idx);
 	if (ptr) {
 		int diff = ptr - str;
-		char *nstr = malloc (lstr + lval + 2);
+		char *nstr = (char *)malloc (lstr + lval + 2);
 		if (!nstr) {
 			return false;
 		}
@@ -560,7 +560,7 @@ SDB_API bool sdb_array_prepend (Sdb *s, const char *key, const char *val, ut32 c
 	cas = kas;
 	if (str && *str) {
 		int val_len = strlen (val);
-		char *newval = malloc (str_len + val_len + 2);
+		char *newval = (char *)malloc (str_len + val_len + 2);
 		if (!newval) {
 			return false;
 		}
@@ -694,7 +694,7 @@ SDB_API void sdb_array_sort_num(Sdb *s, const char *key, ut32 cas) {
 
 	qsort (nums + 1, (int)*nums, sizeof (ut64), int_cmp);
 
-	nstr = malloc (*nums + 1);
+	nstr = (char *)malloc (*nums + 1);
 	if (!nstr) {
 		free (nums);
 		return;

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,4 +1,4 @@
-/* base64 enc/dec - MIT - Copyright 2011-2016 - pancake */
+/* base64 enc/dec - MIT - Copyright 2011-2022 - pancake */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -71,7 +71,7 @@ SDB_API char *sdb_encode(const ut8 *bin, int len) {
 	if (!len) {
 		return strdup ("");
 	}
-	out = calloc (8 + (len * 2), sizeof (char));
+	out = (char *)calloc (8 + (len * 2), sizeof (char));
 	if (!out) {
 		return NULL;
 	}
@@ -79,7 +79,7 @@ SDB_API char *sdb_encode(const ut8 *bin, int len) {
 	return out;
 }
 
-SDB_API ut8 *sdb_decode (const char *in, int *len) {
+SDB_API ut8 *sdb_decode(const char *in, int *len) {
 	ut8 *out;
 	ut32 size;
 	int olen, ilen;
@@ -89,7 +89,7 @@ SDB_API ut8 *sdb_decode (const char *in, int *len) {
 	if (!in) {
 		return NULL;
 	}
-	ilen = strlen (in);
+	ilen = (int)strlen (in);
 	if (!ilen) {
 		return NULL;
 	}
@@ -97,7 +97,7 @@ SDB_API ut8 *sdb_decode (const char *in, int *len) {
 	if (size < (ut32)ilen) {
 		return NULL;
 	}
-	out = calloc (1, size);
+	out = (ut8 *)calloc (1, size);
 	if (!out) {
 		return NULL;
 	}

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -3,6 +3,10 @@
 
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int (*BufferOp)(int, const char *, int);
 
 typedef struct buffer {
@@ -17,12 +21,12 @@ typedef struct buffer {
 #define BUFFER_INSIZE 8192
 #define BUFFER_OUTSIZE 8192
 
-extern void buffer_init(buffer *,BufferOp,int,char *,unsigned int);
+void buffer_init(buffer *,BufferOp,int,char *,unsigned int);
 
-extern int buffer_flush(buffer *);
-extern int buffer_put(buffer *,const char *,unsigned int);
-extern int buffer_putalign(buffer *,const char *,unsigned int);
-extern int buffer_putflush(buffer *,const char *,unsigned int);
+int buffer_flush(buffer *);
+int buffer_put(buffer *,const char *,unsigned int);
+int buffer_putalign(buffer *,const char *,unsigned int);
+int buffer_putflush(buffer *,const char *,unsigned int);
 
 #define buffer_PUTC(s,c) \
   ( ((s)->n != (s)->p) \
@@ -30,12 +34,12 @@ extern int buffer_putflush(buffer *,const char *,unsigned int);
     : buffer_put((s),&(c),1) \
   )
 
-extern int buffer_get(buffer *,char *,unsigned int);
-extern int buffer_bget(buffer *,char *,unsigned int);
-extern int buffer_feed(buffer *);
+int buffer_get(buffer *,char *,unsigned int);
+int buffer_bget(buffer *,char *,unsigned int);
+int buffer_feed(buffer *);
 
-extern char *buffer_peek(buffer *);
-extern void buffer_seek(buffer *,unsigned int);
+char *buffer_peek(buffer *);
+void buffer_seek(buffer *,unsigned int);
 
 #define buffer_PEEK(s) ( (s)->x + (s)->n )
 #define buffer_SEEK(s,len) ( ( (s)->p -= (len) ) , ( (s)->n += (len) ) )
@@ -46,12 +50,19 @@ extern void buffer_seek(buffer *,unsigned int);
     : buffer_get((s),(c),1) \
   )
 
-extern int buffer_copy(buffer *,buffer *);
+int buffer_copy(buffer *,buffer *);
 
+// WTF GLOBALS
+#if 0
 extern buffer *buffer_0;
 extern buffer *buffer_0small;
 extern buffer *buffer_1;
 extern buffer *buffer_1small;
 extern buffer *buffer_2;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/cdb.c
+++ b/src/cdb.c
@@ -54,7 +54,7 @@ bool cdb_init(struct cdb *c, int fd) {
 	cdb_findstart (c);
 	if (fd != -1 && !fstat (fd, &st) && st.st_size > 4 && st.st_size != (off_t)UT64_MAX) {
 #if USE_MMAN
-		char *x = mmap (0, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
+		char *x = (char *)mmap (0, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
 		if (x == MAP_FAILED) {
 			eprintf ("Cannot mmap %d\n", (int)st.st_size);
 			return false;

--- a/src/cdb.h
+++ b/src/cdb.h
@@ -3,6 +3,10 @@
 #ifndef CDB_H
 #define CDB_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <string.h>
 #include "types.h"
 
@@ -35,5 +39,9 @@ int cdb_findnext(struct cdb *, ut32 u, const char *, ut32);
 
 #define cdb_datapos(c) ((c)->dpos)
 #define cdb_datalen(c) ((c)->dlen)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/cdb_make.c
+++ b/src/cdb_make.c
@@ -11,11 +11,11 @@
 char *cdb_alloc(ut32 n) {
 #if __APPLE__ && !__POWERPC__
 	void *ret = NULL;
-	return posix_memalign (&ret, ALIGNMENT, n)? NULL: ret;
+	return (char *)posix_memalign (&ret, ALIGNMENT, n)? NULL: ret;
 #elif __SDB_WINDOWS__ && !__CYGWIN__
-	return _aligned_malloc (n, ALIGNMENT);
+	return (char *)_aligned_malloc (n, ALIGNMENT);
 #else
-	return malloc (n);
+	return (char *)malloc (n);
 #endif
 }
 

--- a/src/cdb_make.h
+++ b/src/cdb_make.h
@@ -31,10 +31,10 @@ struct cdb_make {
 	int fd;
 };
 
-extern int cdb_make_start(struct cdb_make *,int);
-extern int cdb_make_addbegin(struct cdb_make *,unsigned int,unsigned int);
-extern int cdb_make_addend(struct cdb_make *,unsigned int,unsigned int,ut32);
-extern int cdb_make_add(struct cdb_make *,const char *,unsigned int,const char *,unsigned int);
-extern int cdb_make_finish(struct cdb_make *);
+int cdb_make_start(struct cdb_make *, int);
+int cdb_make_addbegin(struct cdb_make *, unsigned int, unsigned int);
+int cdb_make_addend(struct cdb_make *, unsigned int, unsigned int,ut32);
+int cdb_make_add(struct cdb_make *, const char *, unsigned int, const char *, unsigned int);
+int cdb_make_finish(struct cdb_make *);
 
 #endif

--- a/src/diff.c
+++ b/src/diff.c
@@ -24,7 +24,7 @@ SDB_API int sdb_diff_format(char *str, int size, const SdbDiff *diff) {
 
 	SdbListIter *it;
 	const char *component;
-	ls_foreach (diff->path, it, component) {
+	ls_foreach_cast (diff->path, it, const char *, component) {
 		APPENDF ("%s/", component);
 	}
 
@@ -74,7 +74,7 @@ typedef struct sdb_diff_kv_cb_ctx {
 } SdbDiffKVCbCtx;
 
 static bool sdb_diff_report_kv_cb(void *user, const char *k, const char *v) {
-	const SdbDiffKVCbCtx *ctx = user;
+	const SdbDiffKVCbCtx *ctx = (const SdbDiffKVCbCtx *)user;
 	sdb_diff_report_kv (ctx->ctx, k, v, ctx->add);
 	return true;
 }
@@ -85,7 +85,7 @@ static bool sdb_diff_report_kv_cb(void *user, const char *k, const char *v) {
 static void sdb_diff_report(SdbDiffCtx *ctx, Sdb *sdb, bool add) {
 	SdbListIter *it;
 	SdbNs *ns;
-	ls_foreach (sdb->ns, it, ns) {
+	ls_foreach_cast (sdb->ns, it, SdbNs*, ns) {
 		sdb_diff_report_ns (ctx, ns, add);
 		ls_push (ctx->path, ns->name);
 		sdb_diff_report (ctx, ns->sdb, add);
@@ -96,7 +96,7 @@ static void sdb_diff_report(SdbDiffCtx *ctx, Sdb *sdb, bool add) {
 }
 
 static bool sdb_diff_kv_cb(void *user, const char *k, const char *v) {
-	const SdbDiffKVCbCtx *ctx = user;
+	const SdbDiffKVCbCtx *ctx = (SdbDiffKVCbCtx *)user;
 	Sdb *other = ctx->add ? ctx->ctx->a : ctx->ctx->b;
 	const char *other_val = sdb_const_get (other, k, NULL);
 	if (!other_val || !*other_val) {
@@ -115,7 +115,7 @@ static bool sdb_diff_kv_cb(void *user, const char *k, const char *v) {
 static void sdb_diff_ctx(SdbDiffCtx *ctx) {
 	SdbListIter *it;
 	SdbNs *ns;
-	ls_foreach (ctx->a->ns, it, ns) {
+	ls_foreach_cast (ctx->a->ns, it, SdbNs*, ns) {
 		Sdb *b_ns = sdb_ns (ctx->b, ns->name, false);
 		if (!b_ns) {
 			DIFF (ctx,
@@ -136,7 +136,7 @@ static void sdb_diff_ctx(SdbDiffCtx *ctx) {
 		ctx->a = a;
 		ctx->b = b;
 	}
-	ls_foreach (ctx->b->ns, it, ns) {
+	ls_foreach_cast (ctx->b->ns, it, SdbNs*, ns) {
 		if (!sdb_ns (ctx->a, ns->name, false)) {
 			DIFF (ctx,
 				sdb_diff_report_ns (ctx, ns, true);

--- a/src/disk.c
+++ b/src/disk.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2013-2018 - pancake */
+/* sdb - MIT - Copyright 2013-2022 - pancake */
 
 #include <stdio.h>
 #include <fcntl.h>
@@ -93,7 +93,7 @@ SDB_API bool sdb_disk_create(Sdb* s) {
 	dir = s->dir ? s->dir : "./";
 	R_FREE (s->ndump);
 	nlen = strlen (dir);
-	str = malloc (nlen + 5);
+	str = (char *)malloc (nlen + 5);
 	if (!str) {
 		return false;
 	}

--- a/src/fmt.c
+++ b/src/fmt.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2014-2018 - pancake */
+/* sdb - MIT - Copyright 2014-2022 - pancake */
 
 #include "sdb.h"
 #include <stdarg.h>
@@ -8,15 +8,16 @@
 // TODO: Add 'a' format for array of pointers null terminated??
 // XXX SLOW CONCAT
 #define concat(x) if (x) { \
-	int size = 2+strlen(x?x:"")+(out?strlen(out)+4:0); \
-	if (out) { char *o = realloc (out, size); \
-		if (o) {\
-			strcat (o, ",");\
-			strcat (o, x);\
-			out = o;\
+	int size = 2 + strlen (x? x: "")+(out? strlen (out) + 4: 0); \
+	if (out) { \
+		char *o = (char *)realloc (out, size); \
+		if (o) { \
+			strcat (o, ","); \
+			strcat (o, x); \
+			out = o; \
 		} \
-	} else {\
-		out = strdup (x);\
+	} else { \
+		out = strdup (x); \
 	} \
 }
 
@@ -145,12 +146,8 @@ SDB_API int sdb_fmt_init (void *p, const char *fmt) {
 }
 
 static const char *sdb_anext2(const char *str, const char **next) {
-	char *nxt, *p = strchr (str, SDB_RS);
-	if (p) {
-		nxt = p + 1;
-	} else {
-		nxt = NULL;
-	}
+	const char *p = strchr (str, SDB_RS);
+	const char *nxt = (p) ?  p + 1: NULL;
 	if (next) {
 		*next = nxt;
 	}

--- a/src/ht.inc
+++ b/src/ht.inc
@@ -99,14 +99,14 @@ static inline HT_(Kv) *next_kv(HtName_(Ht) *ht, HT_(Kv) *kv) {
 // pair_free - function for freeing a keyvaluepair - if NULL just does free.
 // calcsize - function to calculate the size of a value. if NULL, just stores 0.
 static HtName_(Ht)* internal_ht_new(ut32 size, ut32 prime_idx, HT_(Options) *opt) {
-	HtName_(Ht)* ht = calloc (1, sizeof (*ht));
+	HtName_(Ht)* ht = (HtName_(Ht)*)calloc (1, sizeof (*ht));
 	if (!ht) {
 		return NULL;
 	}
 	ht->size = size;
 	ht->count = 0;
 	ht->prime_idx = prime_idx;
-	ht->table = calloc (ht->size, sizeof (*ht->table));
+	ht->table = (HT_(Bucket)*)calloc (ht->size, sizeof (*ht->table));
 	if (!ht->table) {
 		free (ht);
 		return NULL;
@@ -201,7 +201,7 @@ static HT_(Kv) *reserve_kv(HtName_(Ht) *ht, const KEY_TYPE key, const int key_le
 		}
 	}
 
-	HT_(Kv) *newkvarr = realloc (bt->arr, (bt->count + 1) * ht->opt.elem_size);
+	HT_(Kv) *newkvarr = (HT_(Kv)*)realloc (bt->arr, (bt->count + 1) * ht->opt.elem_size);
 	if (!newkvarr) {
 		return NULL;
 	}

--- a/src/ht_inc.h
+++ b/src/ht_inc.h
@@ -1,4 +1,8 @@
-/* radare2 - BSD 3 Clause License - 2016-2021 - crowell */
+/* radare2 - BSD 3 Clause License - 2016-2022 - crowell, pancake */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef HT_TYPE
 #error HT_TYPE should be defined before including this header
@@ -114,5 +118,9 @@ SDB_API void Ht_(foreach)(HtName_(Ht) *ht, HT_(ForeachCallback) cb, void *user);
 
 SDB_API HT_(Kv)* Ht_(find_kv)(HtName_(Ht)* ht, const KEY_TYPE key, bool* found);
 SDB_API bool Ht_(insert_kv)(HtName_(Ht) *ht, HT_(Kv) *kv, bool update);
+
+#ifdef __cplusplus
+}
+#endif
 
 #undef HT_TYPE

--- a/src/ht_pp.c
+++ b/src/ht_pp.c
@@ -1,6 +1,8 @@
+/* sdb - MIT - Copyright 2018-2022 - ret2libc, pancake */
+
 #include "sdb.h"
 #include "ht_pp.h"
-#include "ht_inc.c"
+#include "ht.inc"
 
 static HtName_(Ht)* internal_ht_default_new(ut32 size, ut32 prime_idx, HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) calcsizeV) {
 	HT_(Options) opt = {

--- a/src/ht_pp.h
+++ b/src/ht_pp.h
@@ -10,8 +10,16 @@
 //#include "sdbht.h"
 #include "ht_inc.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SDB_API HtName_(Ht)* Ht_(new0)(void);
 SDB_API HtName_(Ht)* Ht_(new)(HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
 SDB_API HtName_(Ht)* Ht_(new_size)(ut32 initial_size, HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ht_pu.c
+++ b/src/ht_pu.c
@@ -1,6 +1,8 @@
+/* sdb - MIT - Copyright 2018-2022 - ret2libc, pancake */
+
 #include "sdb.h"
 #include "ht_pu.h"
-#include "ht_inc.c"
+#include "ht.inc"
 
 static void free_kv_key(HT_(Kv) *kv) {
 	free (kv->key);

--- a/src/ht_pu.h
+++ b/src/ht_pu.h
@@ -8,7 +8,15 @@
 #define HT_TYPE 4
 #include "ht_inc.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SDB_API HtName_(Ht)* Ht_(new0)(void);
 #undef HT_TYPE
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ht_up.c
+++ b/src/ht_up.c
@@ -1,6 +1,8 @@
+/* sdb - MIT - Copyright 2018-2022 - ret2libc, pancake */
+
 #include "sdb.h"
 #include "ht_up.h"
-#include "ht_inc.c"
+#include "ht.inc"
 
 static HtName_(Ht)* internal_ht_default_new(ut32 size, ut32 prime_idx, HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) calcsizeV) {
 	HT_(Options) opt = {

--- a/src/ht_up.h
+++ b/src/ht_up.h
@@ -10,9 +10,17 @@
 #include "ht_inc.h"
 #include "sdbht.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SDB_API HtName_(Ht)* Ht_(new0)(void);
 SDB_API HtName_(Ht)* Ht_(new)(HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
 SDB_API HtName_(Ht)* Ht_(new_size)(ut32 initial_size, HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
 #undef HT_TYPE
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ht_uu.c
+++ b/src/ht_uu.c
@@ -1,6 +1,8 @@
+/* sdb - MIT - Copyright 2018-2022 - ret2libc, pancake */
+
 #include "sdb.h"
 #include "ht_uu.h"
-#include "ht_inc.c"
+#include "ht.inc"
 
 // creates a default HtUU that has strings as keys
 SDB_API HtName_(Ht)* Ht_(new0)(void) {

--- a/src/ht_uu.h
+++ b/src/ht_uu.h
@@ -10,6 +10,14 @@
 #include "ht_inc.h"
 #include "sdbht.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SDB_API HtName_(Ht)* Ht_(new0)(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/journal.c
+++ b/src/journal.c
@@ -62,7 +62,7 @@ SDB_API int sdb_journal_load(Sdb *s) {
 		return 0;
 	}
 	lseek (fd, 0, SEEK_SET);
-	str = malloc (sz + 1);
+	str = (char *)malloc (sz + 1);
 	if (!str) {
 		return 0;
 	}

--- a/src/json.c
+++ b/src/json.c
@@ -120,7 +120,7 @@ SDB_API bool sdb_json_set(Sdb *s, const char *k, const char *p, const char *v, u
 	if (!js) {
 		const int v_len = strlen (v);
 		const int p_len = strlen (p);
-		b = malloc (p_len + v_len + 8);
+		b = (char *)malloc (p_len + v_len + 8);
 		if (b) {
 			int is_str = isstring (v);
 			const char *q = is_str? "\"": "";
@@ -146,7 +146,7 @@ SDB_API bool sdb_json_set(Sdb *s, const char *k, const char *p, const char *v, u
 		// ensured to be positive by sdb_const_get_len
 		// 7 corresponds to the length of '{"":"",'
 		size_t buf_len = jslen + strlen (p) + strlen (v) + 7;
-		char *buf = malloc (buf_len);
+		char *buf = (char *)malloc (buf_len);
 		if (buf) {
 			int curlen, is_str = isstring (v);
 			const char *quote = is_str ? "\"" : "";
@@ -188,7 +188,7 @@ SDB_API bool sdb_json_set(Sdb *s, const char *k, const char *p, const char *v, u
 		if (msz < 1) {
 			return false;
 		}
-		str = malloc (msz);
+		str = (char *)malloc (msz);
 		if (!str) {
 			return false;
 		}
@@ -242,7 +242,7 @@ SDB_API bool sdb_json_set(Sdb *s, const char *k, const char *p, const char *v, u
 			len[2]--;
 		}
 
-		str = malloc (len[0] + len[2] + 1);
+		str = (char *)malloc (len[0] + len[2] + 1);
 		if (!str) {
 			return false;
 		}
@@ -264,7 +264,7 @@ SDB_API const char *sdb_json_format(SdbJsonString *s, const char *fmt, ...) {
 #define JSONSTR_ALLOCATE(y)\
 	if (s->len + y > s->blen) {\
 		s->blen *= 2;\
-		x = realloc (s->buf, s->blen);\
+		x = (char *)realloc (s->buf, s->blen);\
 		if (!x) {\
 			va_end (ap);\
 			return NULL;\
@@ -276,7 +276,7 @@ SDB_API const char *sdb_json_format(SdbJsonString *s, const char *fmt, ...) {
 	}
 	if (!s->buf) {
 		s->blen = 1024;
-		s->buf = malloc (s->blen);
+		s->buf = (char *)malloc (s->blen);
 		if (!s->buf) {
 			return NULL;
 		}
@@ -307,7 +307,7 @@ SDB_API const char *sdb_json_format(SdbJsonString *s, const char *fmt, ...) {
 			case 'l':
 				JSONSTR_ALLOCATE (32);
 				arg_l = va_arg (ap, ut64);
-				snprintf (tmp, sizeof (tmp), "0x%"ULLFMT "x", arg_l);
+				snprintf (tmp, sizeof (tmp), "0x%" ULLFMT "x", arg_l);
 				memcpy (s->buf + s->len, tmp, strlen (tmp));
 				s->len += strlen (tmp);
 				break;

--- a/src/json/api.c
+++ b/src/json/api.c
@@ -35,7 +35,7 @@ char *api_json_set (const char *s, const char *k, const char *v) {
 	end[2] = s + strlen (s);
 	len[2] = WLEN (2);
 
-	str = malloc (len[0]+len[1]+len[2]+1);
+	str = (char *)malloc (len[0]+len[1]+len[2]+1);
 	if (!str) {
 		return NULL;
 	}

--- a/src/json/indent.c
+++ b/src/json/indent.c
@@ -50,7 +50,7 @@ SDB_API char *sdb_json_indent(const char *s, const char *tab) {
 	o_size += 2;
 	indent = 0;
 
-	O = malloc (o_size + 1);
+	O = (char *)malloc (o_size + 1);
 	if (!O) {
 		return NULL;
 	}
@@ -110,7 +110,7 @@ SDB_API char *sdb_json_indent(const char *s, const char *tab) {
 SDB_API char *sdb_json_unindent(const char *s) {
 	int instr = 0;
 	int len = strlen (s);
-	char *o, *O = malloc (len + 1);
+	char *o, *O = (char *)malloc (len + 1);
 	if (!O) {
 		return NULL;
 	}

--- a/src/json/js0n.c
+++ b/src/json/js0n.c
@@ -12,6 +12,8 @@
 #define HAVE_COMPUTED_GOTOS 0
 #elif __EMSCRIPTEN__
 #define HAVE_COMPUTED_GOTOS 0
+#elif __cplusplus
+#define HAVE_COMPUTED_GOTOS 0
 #else
 #define HAVE_COMPUTED_GOTOS 1
 #endif

--- a/src/json/path.c
+++ b/src/json/path.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2012-2017 - pancake */
+/* sdb - MIT - Copyright 2012-2021 - pancake */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,7 +11,7 @@ SDB_IPI void json_path_first(Rangstr *s) {
 	if (!s->p) {
 		return;
 	}
-	p = strchr (s->p, '.');
+	p = (char *)strchr (s->p, '.');
 	s->f = 0;
 	s->t = p? (size_t)(p - s->p): strlen (s->p);
 }
@@ -123,7 +123,7 @@ SDB_IPI Rangstr json_find (const char *s, Rangstr *rs) {
 
 	len = strlen (s);
 	if (len > RESFIXSZ) {
-		res = calloc (len + 1, sizeof (RangstrType));
+		res = (RangstrType *)calloc (len + 1, sizeof (RangstrType));
 		if (!res) {
 			eprintf ("Cannot allocate %d byte%s\n",
 				len + 1, (len > 1)? "s": "");

--- a/src/json/rangstr.c
+++ b/src/json/rangstr.c
@@ -1,4 +1,4 @@
-/* Copyleft 2012-2017 - sdb (aka SimpleDB) - pancake<nopcode.org> */
+/* Copyleft 2012-2022 - sdb - pancake */
 
 #ifndef RANGSTR_C
 #define RANGSTR_C
@@ -8,21 +8,12 @@
 #include <stdlib.h>
 #include "rangstr.h"
 
-#if 0
-SDB_IPI void rangstr_print (Rangstr *s) {
-	if (s && s->p) {
-		(void) fwrite (s->p+s->f,
-			s->t-s->f, 1, stdout);
-	}
-}
-#endif
-
 SDB_IPI Rangstr rangstr_null(void) {
 	Rangstr rs = {0, 0, 0, 0, 0};
 	return rs;
 }
 
-SDB_IPI Rangstr rangstr_new (const char *s) {
+SDB_IPI Rangstr rangstr_new(const char *s) {
 	Rangstr rs;
 	if (!s) {
 		return rangstr_null ();
@@ -35,14 +26,14 @@ SDB_IPI Rangstr rangstr_new (const char *s) {
 	return rs;
 }
 
-SDB_IPI int rangstr_length (Rangstr* rs) {
+SDB_IPI int rangstr_length(Rangstr* rs) {
 	if (rs->t > rs->f) {
 		return rs->t - rs->f;
 	}
 	return 0;
 }
 
-SDB_IPI int rangstr_int (Rangstr *s) {
+SDB_IPI int rangstr_int(Rangstr *s) {
 	if (!s || !s->p) {
 		return 0;
 	}
@@ -70,12 +61,12 @@ SDB_IPI int rangstr_int (Rangstr *s) {
 	return n * mul;
 }
 
-SDB_IPI char *rangstr_dup (Rangstr *rs) {
+SDB_IPI char *rangstr_dup(Rangstr *rs) {
 	if (!rs->p) {
 		return NULL;
 	}
 	int len = rangstr_length (rs);
-	char *p = malloc (len + 1);
+	char *p = (char *)malloc (len + 1);
 	if (p) {
 		memcpy (p, rs->p + rs->f, len);
 		p[len] = 0;
@@ -83,7 +74,7 @@ SDB_IPI char *rangstr_dup (Rangstr *rs) {
 	return p;
 }
 
-SDB_IPI Rangstr rangstr_news (const char *s, RangstrType *res, int i) {
+SDB_IPI Rangstr rangstr_news(const char *s, RangstrType *res, int i) {
 	Rangstr rs;
 	rs.next = 1;
 	rs.f = res[i];
@@ -93,7 +84,7 @@ SDB_IPI Rangstr rangstr_news (const char *s, RangstrType *res, int i) {
 	return rs;
 }
 
-SDB_IPI int rangstr_cmp (Rangstr *a, Rangstr *b) {
+SDB_IPI int rangstr_cmp(Rangstr *a, Rangstr *b) {
 	int la = a->t - a->f;
 	int lb = b->t - b->f;
 	int lbz = strlen (b->p + b->f);
@@ -106,13 +97,13 @@ SDB_IPI int rangstr_cmp (Rangstr *a, Rangstr *b) {
 	return memcmp (a->p + a->f, b->p + b->f, la);
 }
 
-SDB_IPI int rangstr_find (Rangstr* a, char ch) {
+SDB_IPI int rangstr_find(Rangstr* a, char ch) {
 	size_t i = a->f;
 	while (i < a->t && a->p[i] && a->p[i] != ch) i++;
 	return (i < a->t && a->p[i]) ? (int) i: -1;
 }
 
-SDB_IPI  const char *rangstr_str (Rangstr* rs) {
+SDB_IPI const char *rangstr_str(Rangstr* rs) {
 	return rs->p + rs->f;
 }
 

--- a/src/ls.h
+++ b/src/ls.h
@@ -4,6 +4,10 @@
 #include <stdio.h>
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void (*SdbListFree)(void *ptr);
 typedef int (*SdbListComparator)(const void *a, const void *b);
 
@@ -22,17 +26,19 @@ typedef struct ls_t {
 } SdbList;
 
 #define ls_foreach(list, it, pos) \
-	if ((list))               \
-		for (it = (list)->head; it && (pos = it->data); it = it->n)
-#define ls_foreach_safe(list, it, tmp, pos) \
-	if ((list))                         \
-		for (it = list->head;       \
-		     it && (pos = it->data) && ((tmp = it->n) || 1); it = tmp)
-#define ls_foreach_prev(list, it, pos) \
-	if ((list))                    \
-		for (it = list->tail; it && (pos = it->data); it = it->p)
+	if ((list)) for (it = (list)->head; it && (pos = it->data); it = it->n)
 
-#define ls_iterator(x) (x)?(x)->head:NULL
+#define ls_foreach_cast(list, it, T, pos) \
+	if ((list)) for (it = (list)->head; it && (pos = (T)((it)->data)); it = (it)->n)
+
+#define ls_foreach_safe(list, it, tmp, pos) \
+	if ((list)) for (it = list->head; it && (pos = it->data) && ((tmp = it->n) || 1); it = tmp)
+
+#define ls_foreach_prev(list, it, pos) \
+	if ((list)) for (it = list->tail; it && (pos = it->data); it = it->p)
+
+#define ls_iterator(x) ((x)? (x)->head: NULL)
+
 // #define ls_empty(x) (!x || (!x->head && !x->tail))
 #define ls_empty(x) (!x || !x->length)
 #define ls_head(x) x->head
@@ -71,5 +77,9 @@ SDB_API int ls_join(SdbList *first, SdbList *second);
 SDB_API int ls_del_n(SdbList *list, int n);
 SDB_API SdbListIter *ls_insert(SdbList *list, int n, void *data);
 SDB_API void *ls_pop_head(SdbList *list);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2011-2021 - pancake */
+/* sdb - MIT - Copyright 2011-2022 - pancake */
 
 #include <signal.h>
 #include <stdio.h>
@@ -84,7 +84,7 @@ static char *slurp(FILE *f, size_t *sz) {
 		/* run test/add10k.sh script to benchmark */
 		const int buf_size = 96096;
 
-		buf = calloc (1, buf_size);
+		buf = (char *)calloc (1, buf_size);
 		if (!buf) {
 			return NULL;
 		}
@@ -103,7 +103,7 @@ static char *slurp(FILE *f, size_t *sz) {
 			buf[buf_len - 1] = '\0';
 		}
 
-		char *newbuf = realloc (buf, buf_len + 1);
+		char *newbuf = (char *)realloc (buf, buf_len + 1);
 		// realloc behaves like free if buf_len is 0
 		if (!newbuf) {
 			return buf;
@@ -111,7 +111,7 @@ static char *slurp(FILE *f, size_t *sz) {
 		return newbuf;
 	}
 #endif
-	buf = calloc (BS + 1, 1);
+	buf = (char *)calloc (BS + 1, 1);
 	if (!buf) {
 		return NULL;
 	}
@@ -149,7 +149,7 @@ static char *slurp(FILE *f, size_t *sz) {
 				int nlen = nl - buf;
 				nextlen = len - nlen;
 				if (nextlen > 0) {
-					next = malloc (nextlen + blocksize + 1);
+					next = (char *)malloc (nextlen + blocksize + 1);
 					if (!next) {
 						eprintf ("Cannot malloc %d\n", nextlen);
 						break;
@@ -169,7 +169,7 @@ static char *slurp(FILE *f, size_t *sz) {
 		}
 #endif
 		bufsize += blocksize;
-		tmp = realloc (buf, bufsize + 1);
+		tmp = (char *)realloc (buf, bufsize + 1);
 		if (!tmp) {
 			bufsize -= blocksize;
 			break;
@@ -239,7 +239,7 @@ static char* get_cname(const char*name) {
 	}
 	char *n = strdup (name);
 	char *v, *d = n;
-	for (v=(char*)n; *v; v++) {
+	for (v = (char*)n; *v; v++) {
 		if (*v == '/' || *v == '-') {
 			*d++ = '_';
 			continue;
@@ -254,7 +254,7 @@ static char* get_cname(const char*name) {
 }
 
 static char *escape(const char *b, int ch) {
-	char *a = calloc ((1 + strlen (b)), 4);
+	char *a = (char *)calloc ((1 + strlen (b)), 4);
 	char *c = a;
 	while (*b) {
 		if (*b == ch) {
@@ -293,7 +293,7 @@ static void sdb_dump_cb(MainOptions *mo, const char *k, const char *v, const cha
 		if (!strcmp (v, "true") || !strcmp (v, "false")) {
 			printf ("%s\"%s\":%s", comma, k, v);
 		} else if (sdb_isnum (v)) {
-			printf ("%s\"%s\":%"ULLFMT"u", comma, k, sdb_atoi (v));
+			printf ("%s\"%s\":%" ULLFMT "u", comma, k, sdb_atoi (v));
 		} else if (*v == '{' || *v == '[') {
 			printf ("%s\"%s\":%s", comma, k, v);
 		} else {
@@ -325,7 +325,7 @@ static void sdb_dump_cb(MainOptions *mo, const char *k, const char *v, const cha
 
 static void cgen_header(MainOptions *mo, const char *cname) {
 	if (mo->textmode) {
-		printf ("// SDB-CGEN V"SDB_VERSION"\n");
+		printf ("// SDB-CGEN V" SDB_VERSION "\n");
 		printf ("// gcc -DMAIN=1 %s.c ; ./a.out > %s.h\n", cname, cname);
 		printf ("#include <ctype.h>\n");
 		printf ("#include <stdio.h>\n");
@@ -391,7 +391,7 @@ static void cgen_footer(MainOptions *mo, const char *name, const char *cname) {
 		return;
 	}
 	printf ("%%%%\n");
-	printf ("// SDB-CGEN V"SDB_VERSION"\n");
+	printf ("// SDB-CGEN V" SDB_VERSION "\n");
 	printf ("// %p\n", cname);
 	printf ("typedef int (*GperfForeachCallback)(void *user, const char *k, const char *v);\n");
 	printf ("int gperf_%s_foreach(GperfForeachCallback cb, void *user) {\n", cname);
@@ -491,7 +491,7 @@ static int sdb_dump(MainOptions *mo) {
 		}
 		SdbKv *kv;
 		SdbListIter *it;
-		ls_foreach (l, it, kv) {
+		ls_foreach_cast (l, it, SdbKv*, kv) {
 			const char *k = sdbkv_key (kv);
 			const char *v = sdbkv_value (kv);
 			if (v && *v && grep && !strstr (k, expgrep) && !strstr (v, expgrep)) {
@@ -620,7 +620,7 @@ static int showusage(int o) {
 }
 
 static int showversion(void) {
-	printf ("sdb "SDB_VERSION "\n");
+	printf ("sdb " SDB_VERSION "\n");
 	fflush (stdout);
 	return 0;
 }
@@ -687,7 +687,7 @@ static void dbdiff_cb(const SdbDiff *diff, void *user) {
 	char *buf = sbuf;
 	char *hbuf = NULL;
 	if ((size_t)r >= sizeof (sbuf)) {
-		hbuf = malloc (r + 1);
+		hbuf = (char *)malloc (r + 1);
 		if (!hbuf) {
 			return;
 		}
@@ -741,12 +741,12 @@ static int sdb_system(const char *cmd) {
 
 static int gen_gperf(MainOptions *mo, const char *file, const char *name) {
 	const size_t buf_size = 4096;
-	char *buf = malloc (buf_size);
+	char *buf = (char *)malloc (buf_size);
 	if (!buf) {
 		return -1;
 	}
 	size_t out_size = strlen (file) + 32;
-	char *out = malloc (out_size);
+	char *out = (char *)malloc (out_size);
 	if (!out) {
 		free (buf);
 		return -1;

--- a/src/ns.c
+++ b/src/ns.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2011-2016 - pancake */
+/* sdb - MIT - Copyright 2011-2022 - pancake */
 
 #include "sdb.h"
 
@@ -7,8 +7,8 @@ SDB_API void sdb_ns_lock(Sdb *s, int lock, int depth) {
 	SdbNs *ns;
 	s->ns_lock = lock;
 	if (depth) { // handles -1 as infinite
-		ls_foreach (s->ns, it, ns) {
-			sdb_ns_lock (ns->sdb, lock, depth-1);
+		ls_foreach_cast (s->ns, it, SdbNs*, ns) {
+			sdb_ns_lock (ns->sdb, lock, depth - 1);
 		}
 	}
 }
@@ -16,10 +16,11 @@ SDB_API void sdb_ns_lock(Sdb *s, int lock, int depth) {
 static int in_list(SdbList *list, void *item) {
 	SdbNs *ns;
 	SdbListIter *it;
-	if (list && item)
-	ls_foreach (list, it, ns) {
-		if (item == ns) {
-			return 1;
+	if (list && item) {
+		ls_foreach_cast (list, it, SdbNs*, ns) {
+			if (item == ns) {
+				return 1;
+			}
 		}
 	}
 	return 0;
@@ -38,7 +39,7 @@ static void ns_free(Sdb *s, SdbList *list) {
 		return;
 	}
 	ls_append (list, s);
-	ls_foreach (s->ns, it, ns) {
+	ls_foreach_cast (s->ns, it, SdbNs*, ns) {
 		deleted = 0;
 		next.n = it->n;
 		if (!in_list (list, ns)) {
@@ -98,7 +99,7 @@ static SdbNs *sdb_ns_new (Sdb *s, const char *name, ut32 hash) {
 	} else {
 		dir[0] = 0;
 	}
-	ns = malloc (sizeof (SdbNs));
+	ns = (SdbNs *)malloc (sizeof (SdbNs));
 	if (!ns) {
 		return NULL;
 	}
@@ -130,7 +131,7 @@ SDB_API bool sdb_ns_unset(Sdb *s, const char *name, Sdb *r) {
 	SdbNs *ns;
 	SdbListIter *it;
 	if (s && (name || r)) {
-		ls_foreach (s->ns, it, ns) {
+		ls_foreach_cast (s->ns, it, SdbNs*, ns) {
 			if (name && (!strcmp (name, ns->name))) {
 				ls_delete (s->ns, it);
 				return true;
@@ -151,7 +152,7 @@ SDB_API int sdb_ns_set(Sdb *s, const char *name, Sdb *r) {
 	if (!s || !r || !name) {
 		return 0;
 	}
-	ls_foreach (s->ns, it, ns) {
+	ls_foreach_cast (s->ns, it, SdbNs*, ns) {
 		if (ns->hash == hash) {
 			if (ns->sdb == r) {
 				return 0;
@@ -189,7 +190,7 @@ SDB_API Sdb *sdb_ns(Sdb *s, const char *name, int create) {
 		return NULL;
 	}
 	hash = sdb_hash (name);
-	ls_foreach (s->ns, it, ns) {
+	ls_foreach_cast (s->ns, it, SdbNs*, ns) {
 		if (ns->hash == hash) {
 			return ns->sdb;
 		}
@@ -212,8 +213,9 @@ SDB_API Sdb *sdb_ns_path(Sdb *s, const char *path, int create) {
 	char *ptr, *str;
 	char *slash;
 
-	if (!s || !path || !*path)
+	if (!s || !path || !*path) {
 		return s;
+	}
 	ptr = str = strdup (path);
 	do {
 		slash = strchr (ptr, '/');
@@ -231,7 +233,7 @@ SDB_API Sdb *sdb_ns_path(Sdb *s, const char *path, int create) {
 static void ns_sync(Sdb *s, SdbList *list) {
 	SdbNs *ns;
 	SdbListIter *it;
-	ls_foreach (s->ns, it, ns) {
+	ls_foreach_cast (s->ns, it, SdbNs*, ns) {
 		if (in_list (list, ns)) {
 			continue;
 		}

--- a/src/query.c
+++ b/src/query.c
@@ -1,6 +1,5 @@
 /* sdb - MIT - Copyright 2011-2022 - pancake */
 
-#include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -15,7 +14,7 @@ typedef struct {
 } StrBuf;
 
 static StrBuf* strbuf_new(void) {
-	return calloc (sizeof (StrBuf), 1);
+	return (StrBuf*) calloc (sizeof (StrBuf), 1);
 }
 
 #define NEWLINE_AFTER_QUERY 1
@@ -27,7 +26,7 @@ static StrBuf* strbuf_append(StrBuf *sb, const char *str, const int nl) {
 	int len = strlen (str);
 	if ((sb->len + len + 2) >= sb->size) {
 		int newsize = sb->size + len + 256;
-		char *b = realloc (sb->buf, newsize);
+		char *b = (char *)realloc (sb->buf, newsize);
 		/// TODO perform free and force all callers to update the ref?
 		if (!b) {
 			return NULL;
@@ -90,8 +89,9 @@ typedef struct {
 } ForeachListUser;
 
 static bool foreach_list_cb(void *user, const char *k, const char *v) {
-	ForeachListUser *rlu = user;
-	char *line, *root;
+	ForeachListUser *rlu = (ForeachListUser*)user;
+	char *line = NULL;
+	char *root = NULL;
 	int rlen, klen, vlen;
 	ut8 *v2 = NULL;
 	if (!rlu) {
@@ -108,7 +108,7 @@ static bool foreach_list_cb(void *user, const char *k, const char *v) {
 	vlen = strlen (v);
 	if (root) {
 		rlen = strlen (root);
-		line = malloc (klen + vlen + rlen + 3);
+		line = (char *)malloc (klen + vlen + rlen + 3);
 		if (!line) {
 			free (v2);
 			return false;
@@ -119,7 +119,7 @@ static bool foreach_list_cb(void *user, const char *k, const char *v) {
 		line[rlen + klen + 1] = '=';
 		memcpy (line + rlen + klen + 2, v, vlen + 1);
 	} else {
-		line = malloc (klen + vlen + 2);
+		line = (char *)malloc (klen + vlen + 2);
 		if (!line) {
 			free (v2);
 			return false;
@@ -147,7 +147,7 @@ static void walk_namespace(StrBuf *sb, char *root, int left, char *p, SdbNs *ns,
 	sdb_foreach (ns->sdb, foreach_list_cb, &user);
 
 	/*Pick "sub"-ns*/
-	ls_foreach (ns->sdb->ns, it, n) {
+	ls_foreach_cast (ns->sdb->ns, it, SdbNs*, n) {
 		len = strlen (n->name);
 		p[0] = '/';
 		if (len + 2 < left) {
@@ -174,7 +174,7 @@ SDB_API char *sdb_querys(Sdb *r, char *buf, size_t len, const char *_cmd) {
 	StrBuf *out = strbuf_new ();
 	if ((int)len < 1 || !buf) {
 		bufset = true;
-		buf = malloc ((len = 64));
+		buf = (char *)malloc ((len = 64));
 		if (!buf) {
 			strbuf_free (out);
 			return NULL;
@@ -209,7 +209,7 @@ repeat:
 	if (*p == '#') {
 		char buffer[16];
 		p++;
-		next = strchr (p, ';');
+		next = (char *)strchr (p, ';');
 		if (next) {
 			*next = 0;
 		}
@@ -226,12 +226,12 @@ repeat:
 		p++;
 	}
 	if (next) *next = ';';
-	eq = strchr (p, '=');
+	eq = (char *)strchr (p, '=');
 	if (eq) {
 		d = 1;
 		*eq++ = 0;
 		if (*eq == '$') {
-			next = strchr (eq + 1, ';');
+			next = (char *)strchr (eq + 1, ';');
 			if (next) *next = 0;
 			val = sdb_const_get (s, eq + 1, 0);
 			if (!val) {
@@ -248,7 +248,7 @@ repeat:
 		d = 0;
 	}
 	if (!is_ref) {
-		next = strchr (val? val: cmd, ';');
+		next = (char *)strchr (val? val: cmd, ';');
 	}
 	//if (!val) val = eq;
 	if (!is_ref && val && *val == '"') {
@@ -256,7 +256,7 @@ repeat:
 		// TODO: escape \" too
 		quot = (char*)val;
 next_quote:
-		quot = strchr (quot, '"');
+		quot = (char *)strchr (quot, '"');
 		if (quot) {
 			if (*(quot - 1) == '\\') {
 				memmove (quot - 1, quot, strlen (quot) + 1);
@@ -298,7 +298,7 @@ next_quote:
 			char root[1024]; // limit namespace length?
 			SdbListIter *it;
 			SdbNs *ns;
-			ls_foreach (s->ns, it, ns) {
+			ls_foreach_cast (s->ns, it, SdbNs*, ns) {
 				int name_len = strlen (ns->name);
 				if (name_len < (long)sizeof (root)) {
 					memcpy (root, ns->name, name_len + 1);
@@ -314,7 +314,7 @@ next_quote:
 		if (!strcmp (cmd, "**")) {
 			SdbListIter *it;
 			SdbNs *ns;
-			ls_foreach (s->ns, it, ns) {
+			ls_foreach_cast (s->ns, it, SdbNs*, ns) {
 				out_concat (ns->name);
 			}
 			goto fail;
@@ -324,7 +324,7 @@ next_quote:
 			SdbList *list = sdb_foreach_list (s, true);
 			SdbListIter *iter;
 			SdbKv *kv;
-			ls_foreach (list, iter, kv) {
+			ls_foreach_cast (list, iter, SdbKv*, kv) {
 				foreach_list_cb (&user, sdbkv_key (kv), sdbkv_value (kv));
 			}
 			ls_free (list);
@@ -364,7 +364,7 @@ next_quote:
 			SdbKv *kv;
 			SdbListIter *li;
 			SdbList *l = sdb_foreach_match (s, cmd + 2, false);
-			ls_foreach (l, li, kv) {
+			ls_foreach_cast (l, li, SdbKv*, kv) {
 				strbuf_append (out, sdbkv_key (kv), 0);
 				strbuf_append (out, "=", 0);
 				strbuf_append (out, sdbkv_value (kv), 1);
@@ -378,7 +378,7 @@ next_quote:
 	} else if (*cmd == '+' || *cmd == '-') {
 		d = 1;
 		if (!buf) {
-			buf = calloc (1, len);
+			buf = (char *)calloc (1, len);
 			if (!buf) {
 				goto fail;
 			}
@@ -467,30 +467,30 @@ next_quote:
 			}
 			// keep base
 			if (base == 16) {
-				w = snprintf (buf, len - 1, "0x%"ULLFMT"x", n);
+				w = snprintf (buf, len - 1, "0x%" ULLFMT "x", n);
 				if (w < 0 || (size_t)w > len) {
 					if (bufset && len < 0xff) {
 						free (buf);
-						buf = malloc (len = 0xff);
+						buf = (char *)malloc (len = 0xff);
 						if (!buf) {
 							goto fail;
 						}
 					}
 					bufset = true;
-					snprintf (buf, 0xff, "0x%"ULLFMT"x", n);
+					snprintf (buf, 0xff, "0x%" ULLFMT "x", n);
 				}
 			} else {
-				w = snprintf (buf, len-1, "%"ULLFMT"d", n);
+				w = snprintf (buf, len-1, "%" ULLFMT "d", n);
 				if (w < 0 || (size_t)w > len) {
 					if (bufset && len < 0xff) {
 						free (buf);
-						buf = malloc (len = 0xff);
+						buf = (char *)malloc (len = 0xff);
 						if (!buf) {
 							goto fail;
 						}
 					}
 					bufset = true;
-					snprintf (buf, 0xff, "%"ULLFMT"d", n);
+					snprintf (buf, 0xff, "%" ULLFMT "d", n);
 				}
 			}
 		}
@@ -501,7 +501,7 @@ next_quote:
 			// if (!eq) ...
 			alength = sdb_array_length (s, p);
 			if (!buf) {
-				buf = malloc (++len);
+				buf = (char *)malloc (++len);
 				if (!buf) {
 					goto fail;
 				}
@@ -512,7 +512,7 @@ next_quote:
 				if (bufset) {
 					free (buf);
 				}
-				buf = malloc (len = 32);
+				buf = (char *)malloc (len = 32);
 				bufset = 1;
 				snprintf (buf, 31, "%d", alength);
 			}
@@ -602,7 +602,7 @@ next_quote:
 						char *tmp = sdb_array_get (s, p, -i, NULL);
 						if (tmp) {
 							if (encode) {
-								char *newtmp = (void*)sdb_decode (tmp, NULL);
+								char *newtmp = (char*)sdb_decode (tmp, NULL);
 								if (!newtmp) {
 									goto fail;
 								}
@@ -691,7 +691,7 @@ next_quote:
 						len = strlen (buf) + 1;
 					}
 					if (encode) {
-						char *newbuf = (void*)sdb_decode (buf, NULL);
+						char *newbuf = (char*)sdb_decode (buf, NULL);
 						if (newbuf) {
 							free (buf);
 							buf = newbuf;
@@ -705,7 +705,7 @@ next_quote:
 					}
 					wl = strlen (sval);
 					if (!buf || wl >= len) {
-						buf = malloc (wl + 2);
+						buf = (char *)malloc (wl + 2);
 						if (!buf) {
 							free (out->buf);
 							out->buf = NULL;
@@ -724,7 +724,7 @@ next_quote:
 					}
 					buf[i] = 0;
 					if (encode) {
-						char *newbuf = (void*)sdb_decode (buf, NULL);
+						char *newbuf = (char*)sdb_decode (buf, NULL);
 						if (newbuf) {
 							if (bufset) {
 								free (buf);
@@ -778,7 +778,7 @@ next_quote:
 					// TODO: not optimized to reuse 'buf'
 					if ((tmp = sdb_json_get (s, cmd, json, 0))) {
 						if (encode) {
-							char *newtmp = (void*)sdb_decode (tmp, NULL);
+							char *newtmp = (char*)sdb_decode (tmp, NULL);
 							if (!newtmp)
 								goto fail;
 							free (tmp);
@@ -797,7 +797,7 @@ next_quote:
 				// sdbget
 				if ((q = sdb_const_get (s, cmd, 0))) {
 					if (encode) {
-						q = (void*)sdb_decode (q, NULL);
+						q = (char*)sdb_decode (q, NULL);
 					}
 					out_concat (q);
 					if (encode) {
@@ -890,7 +890,7 @@ static char *slurp(const char *file) {
 		return NULL;
 	}
 	lseek (fd, 0, SEEK_SET);
-	char *text = malloc (sz + 1);
+	char *text = (char *)malloc (sz + 1);
 	if (!text) {
 		close (fd);
 		return NULL;

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -62,7 +62,7 @@ SDB_API Sdb* sdb_new(const char *path, const char *name, int lock) {
 		if (path && *path) {
 			size_t plen = strlen (path);
 			size_t nlen = strlen (name);
-			s->dir = malloc (plen + nlen + 2);
+			s->dir = (char *)malloc (plen + nlen + 2);
 			if (!s->dir) {
 				free (s);
 				return NULL;
@@ -144,7 +144,7 @@ SDB_API void sdb_file(Sdb* s, const char *dir) {
 }
 
 static bool sdb_merge_cb(void *user, const char *k, const char *v) {
-	sdb_set (user, k, v, 0);
+	sdb_set ((Sdb*)user, k, v, 0);
 	return true;
 }
 
@@ -355,7 +355,7 @@ SDB_API int sdb_concat(Sdb *s, const char *key, const char *value, ut32 cas) {
 		return sdb_set (s, key, value, cas);
 	}
 	vl = strlen (value);
-	o = malloc (kl + vl + 1);
+	o = (char *)malloc (kl + vl + 1);
 	if (o) {
 		memcpy (o, p, kl);
 		memcpy (o + kl, value, vl + 1);
@@ -583,7 +583,7 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, bool owned, ut3
 		if (owned) {
 			val = strdup ("");
 		} else {
-			val = "";
+			val = (char *)"";
 		}
 	}
 	// XXX strlen computed twice.. because of check_*()
@@ -672,7 +672,8 @@ static bool sdb_foreach_list_cb(void *user, const char *k, const char *v) {
 }
 
 static int __cmp_asc(const void *a, const void *b) {
-	const SdbKv *ka = a, *kb = b;
+	const SdbKv *ka = (SdbKv *)a;
+	const SdbKv *kb = (SdbKv *)b;
 	return strcmp (sdbkv_key (ka), sdbkv_key (kb));
 }
 
@@ -737,7 +738,9 @@ typedef struct {
 
 static bool sdb_foreach_match_cb(void *user, const char *k, const char *v) {
 	_match_sdb_user *o = (_match_sdb_user*)user;
-	SdbKv tkv = { .base.key = (char*)k, .base.value = (char*)v };
+	SdbKv tkv = {0};
+	tkv.base.key = (char *)k;
+	tkv.base.value = (char *)v;
 	if (sdbkv_match (&tkv, o->expr)) {
 		SdbKv *kv = R_NEW0 (SdbKv);
 		kv->base.key = strdup (k);
@@ -966,7 +969,7 @@ SDB_API bool sdb_dump_dupnext(Sdb* s, char *key, char **value, int *_vlen) {
 	if (value) {
 		*value = 0;
 		if (vlen < SDB_MAX_VALUE) {
-			*value = malloc (vlen + 10);
+			*value = (char *)malloc (vlen + 10);
 			if (!*value) {
 				return false;
 			}
@@ -1021,7 +1024,7 @@ SDB_API bool sdb_expire_set(Sdb* s, const char *key, ut64 expire, ut32 cas) {
 	if (len < 1 || len >= INT32_MAX) {
 		return false;
 	}
-	if (!(buf = calloc (1, len + 1))) {
+	if (!(buf = (char *)calloc (1, len + 1))) {
 		return false;
 	}
 	cdb_read (&s->db, buf, len, pos);
@@ -1047,7 +1050,7 @@ SDB_API bool sdb_hook(Sdb* s, SdbHook cb, void* user) {
 	SdbHook hook;
 	SdbListIter *iter;
 	if (s->hooks) {
-		ls_foreach (s->hooks, iter, hook) {
+		ls_foreach_cast (s->hooks, iter, SdbHook, hook) {
 			if (!(i % 2) && (hook == cb)) {
 				return false;
 			}
@@ -1066,7 +1069,7 @@ SDB_API bool sdb_unhook(Sdb* s, SdbHook h) {
 	int i = 0;
 	SdbHook hook;
 	SdbListIter *iter, *iter2;
-	ls_foreach (s->hooks, iter, hook) {
+	ls_foreach_cast (s->hooks, iter, SdbHook, hook) {
 		if (!(i % 2) && (hook == h)) {
 			iter2 = iter->n;
 			ls_delete (s->hooks, iter);
@@ -1085,7 +1088,7 @@ SDB_API int sdb_hook_call(Sdb *s, const char *k, const char *v) {
 	if (s->timestamped && s->last) {
 		s->last = sdb_now ();
 	}
-	ls_foreach (s->hooks, iter, hook) {
+	ls_foreach_cast (s->hooks, iter, SdbHook, hook) {
 		if (!(i % 2) && k && iter->n) {
 			void *u = iter->n->data;
 			hook (s, u, k, v);
@@ -1138,7 +1141,7 @@ SDB_API void sdb_drain(Sdb *s, Sdb *f) {
 }
 
 static bool copy_foreach_cb(void *user, const char *k, const char *v) {
-	Sdb *dst = user;
+	Sdb *dst = (Sdb *)user;
 	sdb_set (dst, k, v, 0);
 	return true;
 }
@@ -1147,7 +1150,7 @@ SDB_API void sdb_copy(Sdb *src, Sdb *dst) {
 	sdb_foreach (src, copy_foreach_cb, dst);
 	SdbListIter *it;
 	SdbNs *ns;
-	ls_foreach (src->ns, it, ns) {
+	ls_foreach_cast (src->ns, it, SdbNs*, ns) {
 		sdb_copy (ns->sdb, sdb_ns (dst, ns->name, true));
 	}
 }
@@ -1158,7 +1161,7 @@ typedef struct {
 } UnsetCallbackData;
 
 static bool unset_cb(void *user, const char *k, const char *v) {
-	UnsetCallbackData *ucd = user;
+	UnsetCallbackData *ucd = (UnsetCallbackData *)user;
 	if (sdb_match (k, ucd->key)) {
 		sdb_unset (ucd->sdb, k, 0);
 	}
@@ -1181,7 +1184,7 @@ typedef struct {
 } LikeCallbackData;
 
 static bool like_cb(void *user, const char *k, const char *v) {
-	LikeCallbackData *lcd = user;
+	LikeCallbackData *lcd = (LikeCallbackData *)user;
 	if (!user) {
 		return false;
 	}
@@ -1227,7 +1230,7 @@ SDB_API char** sdb_like(Sdb *s, const char *k, const char *v, SdbForeachCallback
 		lcd.val = NULL;
 	}
 	lcd.array_size = sizeof (char*) * 2;
-	lcd.array = calloc (lcd.array_size, 1);
+	lcd.array = (const char **)calloc (lcd.array_size, 1); // XXX shouldnt be const
 	if (!lcd.array) {
 		return NULL;
 	}

--- a/src/sdbht.c
+++ b/src/sdbht.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2011-2020 - pancake */
+/* sdb - MIT - Copyright 2011-2022 - pancake */
 
 #include "sdbht.h"
 
@@ -20,16 +20,16 @@ static bool sdb_ht_internal_insert(HtPP* ht, const char* key, const char* value,
 		return false;
 	}
 	SdbKv kvp = {{ 0 }};
-	kvp.base.key = strdup ((void *)key);
+	kvp.base.key = strdup (key);
 	if (!kvp.base.key) {
 		goto err;
 	}
-	kvp.base.value = strdup ((void *)value);
+	kvp.base.value = strdup (value);
 	if (!kvp.base.value) {
 		goto err;
 	}
-	kvp.base.key_len = strlen (kvp.base.key);
-	kvp.base.value_len = strlen (kvp.base.value);
+	kvp.base.key_len = strlen ((const char *)kvp.base.key);
+	kvp.base.value_len = strlen ((const char *)kvp.base.value);
 	kvp.expire = 0;
 	return ht_pp_insert_kv (ht, (HtPPKv*)&kvp, update);
 

--- a/src/sdbht.h
+++ b/src/sdbht.h
@@ -3,6 +3,10 @@
 
 #include "ht_pp.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** keyvalue pair **/
 typedef struct sdb_kv {
 	//sub of HtPPKv so we can cast safely
@@ -48,5 +52,9 @@ SDB_API bool sdb_ht_delete(HtPP* ht, const char* key);
 SDB_API char* sdb_ht_find(HtPP* ht, const char* key, bool* found);
 // Find the KeyValuePair corresponding to the matching key.
 SDB_API SdbKv* sdb_ht_find_kvp(HtPP* ht, const char* key, bool* found);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __SDB_HT_H

--- a/src/set.c
+++ b/src/set.c
@@ -15,7 +15,9 @@ static bool u_foreach_cb(void *user, const ut64 k, const void *nada) {
 }
 
 SDB_API void set_u_foreach(SetU *s, set_u_foreach_cb cb, void *userdata) {
-	SetData sd = {cb, userdata};
+	SetData sd;
+	sd.cbptr = (void *)cb;
+	sd.userdata = (void *)userdata;
 	ht_up_foreach (s, u_foreach_cb, &sd);
 }
 
@@ -26,7 +28,9 @@ static bool p_foreach_cb(void *user, const void *k, const void *nada) {
 }
 
 SDB_API void set_p_foreach(SetP *s, set_p_foreach_cb cb, void *userdata) {
-	SetData sd = {cb, userdata};
+	SetData sd;
+	sd.cbptr = (void *)cb;
+	sd.userdata = (void *)userdata;
 	ht_pp_foreach (s, p_foreach_cb, &sd);
 }
 ////

--- a/src/set.h
+++ b/src/set.h
@@ -4,6 +4,10 @@
 #include "ht_pp.h"
 #include "ht_up.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef HtPP SetP;
 typedef bool (*set_p_foreach_cb)(void *userdata, const void *p);
 typedef bool (*set_u_foreach_cb)(void *userdata, const ut64 u);
@@ -24,5 +28,9 @@ SDB_API void set_u_delete(SetU *s, ut64 u);
 SDB_API void set_u_free(SetU *p);
 
 SDB_API void set_u_foreach(SetU *s, set_u_foreach_cb cb, void *u);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/text.c
+++ b/src/text.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2020-2021 - thestr4ng3r */
+/* sdb - MIT - Copyright 2020-2022 - pancake, thestr4ng3r */
 
 #include "sdb.h"
 
@@ -8,6 +8,9 @@
 #if USE_MMAN
 #include <sys/mman.h>
 #endif
+
+// TODO: set this to 0 when properly reviewed and cleaned
+#define OLD_MAGIC 1
 
 /**
  * ********************
@@ -60,15 +63,18 @@
 */
 
 static int cmp_ns(const void *a, const void *b) {
-	const SdbNs *nsa = a;
-	const SdbNs *cia = b;
+	const SdbNs *nsa = (const SdbNs *)a;
+	const SdbNs *cia = (const SdbNs *)b;
 	return strcmp (nsa->name, cia->name);
 }
+
 
 // n = position we are currently looking at
 // p = position until we have already written everything
 // flush a block of text that doesn't have to be escaped
 #define FLUSH do { if (p != n) { (void)write (fd, p, n - p); p = n; } } while (0)
+
+#if OLD_MAGIC
 // write and escape a string from str to fd
 #define ESCAPE_LOOP(fd, str, escapes) do { \
 		const char *p = str; \
@@ -79,12 +85,44 @@ static int cmp_ns(const void *a, const void *b) {
 		} \
 		FLUSH; \
 	} while (0)
-#define ESCAPE(c, repl, replsz) \
+
+#define ESCAPE(c, repl) \
 		case c: \
 			FLUSH; \
 			p++; \
-			if (write (fd, "\\"repl, replsz + 1) != replsz + 1) { return false; }; \
+			if (write (fd, "\\" repl, 2) != 2) { return false; }; \
 			break;
+
+#else
+static bool escape_loop(int fd, const char *str, char ch) {
+	const char *p = str;
+	const char *n = p;
+	while (*n) {
+		switch (*n) {
+		case '\\':
+			if (write (fd, "\\\\", 2) != 2) { return false; }
+			break;
+		case '\r':
+			if (write (fd, "\\r", 2) != 2) { return false; }
+			break;
+		case '\n':
+			if (write (fd, "\\n", 2) != 2) { return false; }
+			break;
+		default:
+			if (ch) {
+				if (*n == ch) {
+					char pair[2] = {ch, 0};
+					if (write (fd, pair, 2) != 2) { return false; }
+				}
+			}
+			break;
+		}
+		n++;
+	}
+	FLUSH;
+	return true;
+}
+#endif
 
 static bool write_path(int fd, SdbList *path) {
 	if (write (fd, "/", 1) != 1) { // always print a /, even if path is empty
@@ -93,7 +131,7 @@ static bool write_path(int fd, SdbList *path) {
 	SdbListIter *it;
 	const char *path_token;
 	bool first = true;
-	ls_foreach (path, it, path_token) {
+	ls_foreach_cast (path, it, const char *, path_token) {
 		if (first) {
 			first = false;
 		} else {
@@ -101,12 +139,16 @@ static bool write_path(int fd, SdbList *path) {
 				return false;
 			}
 		}
+#if OLD_MAGIC
 		ESCAPE_LOOP (fd, path_token,
-			ESCAPE ('\\', "\\", 1);
-			ESCAPE ('/', "/", 1);
-			ESCAPE ('\n', "n", 1);
-			ESCAPE ('\r', "r", 1);
+			ESCAPE ('\\', "\\");
+			ESCAPE ('/', "/");
+			ESCAPE ('\n', "n");
+			ESCAPE ('\r', "r");
 		);
+#else
+		escape_loop (fd, path_token, '/');
+#endif
 	}
 	return true;
 }
@@ -118,29 +160,37 @@ static bool write_key(int fd, const char *k) {
 			return false;
 		}
 	}
+#if OLD_MAGIC
 	ESCAPE_LOOP (fd, k,
-		ESCAPE ('\\', "\\", 1);
-		ESCAPE ('=', "=", 1);
-		ESCAPE ('\n', "n", 1);
-		ESCAPE ('\r', "r", 1);
+		ESCAPE ('\\', "\\");
+		ESCAPE ('=', "=");
+		ESCAPE ('\n', "n");
+		ESCAPE ('\r', "r");
 	);
 	return true;
+#else
+	return escape_loop (fd, k, '=');
+#endif
 }
 
 static bool write_value(int fd, const char *v) {
+#if OLD_MAGIC
 	ESCAPE_LOOP (fd, v,
-		ESCAPE ('\\', "\\", 1);
-		ESCAPE ('\n', "n", 1);
-		ESCAPE ('\r', "r", 1);
+		ESCAPE ('\\', "\\");
+		ESCAPE ('\n', "n");
+		ESCAPE ('\r', "r");
 	);
 	return true;
+#else
+	return escape_loop (fd, v, 0);
+#endif
 }
 #undef FLUSH
 #undef ESCAPE_LOOP
 #undef ESCAPE
 
 static bool save_kv_cb(void *user, const char *k, const char *v) {
-	int fd = *(int *)user;
+	int fd = *((int *)user);
 	if (!write_key (fd, k) || write (fd, "=", 1) != 1) {
 		return false;
 	}
@@ -161,7 +211,7 @@ static bool text_save(Sdb *s, int fd, bool sort, SdbList *path) {
 		SdbList *l = sdb_foreach_list (s, true);
 		SdbKv *kv;
 		SdbListIter *it;
-		ls_foreach (l, it, kv) {
+		ls_foreach_cast (l, it, SdbKv*, kv) {
 			save_kv_cb (&fd, sdbkv_key (kv), sdbkv_value (kv));
 		}
 		ls_free (l);
@@ -178,7 +228,7 @@ static bool text_save(Sdb *s, int fd, bool sort, SdbList *path) {
 	}
 	SdbNs *ns;
 	SdbListIter *it;
-	ls_foreach (l, it, ns) {
+	ls_foreach_cast (l, it, SdbNs*, ns) {
 		if (write (fd, "\n", 1) != 1) {
 			ls_free (l);
 			return false;
@@ -249,7 +299,7 @@ static void load_process_line(LoadCtx *ctx) {
 		SdbListIter *it;
 		void *token_off_tmp;
 		ctx->cur_db = ctx->root_db;
-		ls_foreach (ctx->path, it, token_off_tmp) {
+		ls_foreach_cast (ctx->path, it, void*, token_off_tmp) {
 			size_t token_off = (size_t)token_off_tmp;
 			if (!ctx->buf[token_off]) {
 				continue;
@@ -345,7 +395,7 @@ static bool load_process_final_line(LoadCtx *ctx) {
 	// load_process_line needs ctx.buf[ctx.pos] to be allocated!
 	// so we need room for one additional byte after the buffer.
 	size_t linesz = ctx->bufsz - ctx->line_begin;
-	char *linebuf = malloc (linesz + 1);
+	char *linebuf = (char *)malloc (linesz + 1);
 	if (!linebuf) {
 		return false;
 	}
@@ -357,7 +407,7 @@ static bool load_process_final_line(LoadCtx *ctx) {
 	ctx->token_begin -= ctx->line_begin;
 	SdbListIter *it;
 	void *token_off_tmp;
-	ls_foreach (ctx->path, it, token_off_tmp) {
+	ls_foreach_cast (ctx->path, it, void*, token_off_tmp) {
 		it->data = (void *)((size_t)token_off_tmp - ctx->line_begin);
 	}
 	ctx->line_begin = 0;
@@ -416,17 +466,18 @@ SDB_API bool sdb_text_load(Sdb *s, const char *file) {
 		return false;
 	}
 	bool r = false;
+	char *x = NULL;
 	struct stat st;
 	if (fstat (fd, &st) || !st.st_size) {
 		goto beach;
 	}
 #if USE_MMAN
-	char *x = mmap (0, st.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+	x = (char *)mmap (0, st.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
 	if (x == MAP_FAILED) {
 		goto beach;
 	}
 #else
-	char *x = calloc (1, st.st_size);
+	x = (char *)calloc (1, st.st_size);
 	if (!x) {
 		goto beach;
 	}

--- a/src/types.h
+++ b/src/types.h
@@ -12,7 +12,7 @@
 #undef eprintf
 #define eprintf(...) fprintf(stderr,__VA_ARGS__)
 
-// Copied from https://gcc.gnu.org/wiki/Visibility
+// Inspired in https://gcc.gnu.org/wiki/Visibility
 #ifndef SDB_API
 	#undef SDB_IPI
 	#if defined _WIN32 || defined __CYGWIN__

--- a/test/unit/test_dict.c
+++ b/test/unit/test_dict.c
@@ -1,0 +1,36 @@
+// #include "minunit.h"
+#include <sdb.h>
+
+int main() {
+	dict m;
+	dict_init (&m, 2, free);
+	dict_set (&m, 0x100, 1, NULL);
+	dict_set (&m, 0x200, 2, NULL);
+	dict_set (&m, 0x300, 3, NULL);
+	dict_set (&m, 0x400, 4, NULL);
+	printf ("%d %d\n", (int)dict_get(&m, 0x100), (int)dict_get(&m, 0x200));
+	printf ("%d %d\n", (int)dict_get(&m, 0x300), (int)dict_get(&m, 0x400));
+	if ((int)dict_get (&m, 0x100) != 1) {
+		return 1;
+	}
+	if ((int)dict_get(&m, 0x200) != 2) {
+		return 1;
+	}
+	if ((int)dict_get(&m, 0x300) != 3) {
+		return 1;
+	}
+	if ((int)dict_get(&m, 0x400) != 4) {
+		return 1;
+	}
+
+	dict_stats (&m);
+#if 0
+	dict_set(&m, dict_hash("username"), 1024, NULL);
+	dict_set(&m, 32, 212, strdup("test"));
+	dict_del(&m, dict_hash("username"));
+	printf ("%d\n", (int)dict_get(&m, dict_hash("username")));
+	printf ("%s\n", dict_getu(&m, 32)); //dict_hash("username")));
+#endif
+	dict_fini (&m);
+	return 0;
+}


### PR DESCRIPTION
* Add casts as void* is not typable enough
* Add ls_foreach_cast
* ht_inc.h is now named ht.inc
* Add 'make x' or 'make o' to compile in c++ or in a single shot
* Remove macros from text.c
* Avoid using extern when its not extern
* Add missing license headers

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
