### PR TITLE
Remove all calls to eprintf from library apis

### DIFF
--- a/src/cdb.c
+++ b/src/cdb.c
@@ -54,7 +54,7 @@ bool cdb_init(struct cdb *c, int fd) {
 #if USE_MMAN
 		char *x = (char *)mmap (0, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
 		if (x == MAP_FAILED) {
-			eprintf ("Cannot mmap %d\n", (int)st.st_size);
+			// eprintf ("Cannot mmap %d\n", (int)st.st_size);
 			return false;
 		}
 		if (c->map) {
@@ -63,7 +63,7 @@ bool cdb_init(struct cdb *c, int fd) {
 #else
 		char *x = calloc (1, st.st_size);
 		if (!x) {
-			eprintf ("Cannot malloc %d\n", (int)st.st_size);
+			// eprintf ("Cannot malloc %d\n", (int)st.st_size);
 			return false;
 		}
 		/* TODO: read by chunks instead of a big huge syscall */

--- a/src/dict.c
+++ b/src/dict.c
@@ -2,7 +2,7 @@
 
 #include "sdb.h"
 
-SDB_API dict *dict_new (ut32 size, dict_freecb f) {
+SDB_API dict *dict_new(ut32 size, dict_freecb f) {
 	dict *m = (dict *)calloc (1, sizeof (dict));
 	if (!dict_init (m, R_MAX (size, 1), f)) {
 		free (m);
@@ -19,7 +19,7 @@ static ut32 dict_bucket(dict *m, dicti k) {
 	return 0;
 }
 
-SDB_API bool dict_init (dict *m, ut32 size, dict_freecb f) {
+SDB_API bool dict_init(dict *m, ut32 size, dict_freecb f) {
 	if (m) {
 		memset (m, 0, sizeof (dict));
 		if (size > 0) {
@@ -34,9 +34,9 @@ SDB_API bool dict_init (dict *m, ut32 size, dict_freecb f) {
 	return true;
 }
 
-SDB_API void dict_fini (dict *m) {
-	ut32 i;
+SDB_API void dict_fini(dict *m) {
 	if (m) {
+		ut32 i;
 		if (m->f) {
 			for (i = 0; i < m->size; i++) {
 				dictkv *kv = (dictkv *)m->table[i];
@@ -58,17 +58,19 @@ SDB_API void dict_fini (dict *m) {
 	}
 }
 
-SDB_API void dict_free (dict *m) {
-	dict_fini (m);
-	free (m);
+SDB_API void dict_free(dict *m) {
+	if (m) {
+		dict_fini (m);
+		free (m);
+	}
 }
 
 // collisions are not handled in a dict. use a hashtable if you want to use strings as keys.
-SDB_API dicti dict_hash (const char *s) {
+SDB_API dicti dict_hash(const char *s) {
 	return (dicti)sdb_hash (s);
 }
 
-SDB_API bool dict_set (dict *m, dicti k, dicti v, void *u) {
+SDB_API bool dict_set(dict *m, dicti k, dicti v, void *u) {
 	if (!m || !m->size || k == MHTNO) {
 		return false;
 	}
@@ -112,7 +114,8 @@ SDB_API bool dict_set (dict *m, dicti k, dicti v, void *u) {
 	return false;
 }
 
-SDB_API void dict_stats (dict *m) {
+#if 0
+SDB_API void dict_stats(dict *m) {
 	ut32 i, j;
 	for (i = 0; i < m->size; i++) {
 		printf ("%d: ", i);
@@ -127,8 +130,9 @@ SDB_API void dict_stats (dict *m) {
 		printf ("%d\n", j);
 	}
 }
+#endif
 
-SDB_API dictkv *dict_getr (dict *m, dicti k) {
+SDB_API dictkv *dict_getr(dict *m, dicti k) {
 	if (!m->size) {
 		return NULL;
 	}
@@ -145,23 +149,23 @@ SDB_API dictkv *dict_getr (dict *m, dicti k) {
 	return NULL;
 }
 
-SDB_API dicti dict_get (dict *m, dicti k) {
+SDB_API dicti dict_get(dict *m, dicti k) {
 	dictkv *kv = dict_getr (m, k);
 	return kv ? kv->v : MHTNO;
 }
 
-SDB_API void *dict_getu (dict *m, dicti k) {
+SDB_API void *dict_getu(dict *m, dicti k) {
 	dictkv *kv = dict_getr (m, k);
 	return kv ? kv->u : NULL;
 }
 
-SDB_API bool dict_add (dict *m, dicti k, dicti v, void *u) {
+SDB_API bool dict_add(dict *m, dicti k, dicti v, void *u) {
 	return dict_getr (m, k)
 		? dict_set (m, k, v, u)
 		: false;
 }
 
-SDB_API bool dict_del (dict *m, dicti k) {
+SDB_API bool dict_del(dict *m, dicti k) {
 	int bucket = dict_bucket (m, k);
 	if (k == MHTNO) {
 		return false;
@@ -191,7 +195,7 @@ SDB_API bool dict_del (dict *m, dicti k) {
 // cb : function that accept a dictkv. When it returns a value != 0, the
 //      iteration stops
 // u : additional information to pass to cb together with the dictkv
-SDB_API void dict_foreach (dict *m, dictkv_cb cb, void *u) {
+SDB_API void dict_foreach(dict *m, dictkv_cb cb, void *u) {
 	bool iterate = true;
 	ut32 i;
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -114,11 +114,12 @@ SDB_API bool dict_set(dict *m, dicti k, dicti v, void *u) {
 	return false;
 }
 
-#if 0
-SDB_API void dict_stats(dict *m) {
+SDB_API ut32 dict_stats(dict *m, int nb) {
 	ut32 i, j;
-	for (i = 0; i < m->size; i++) {
-		printf ("%d: ", i);
+	if (nb < 0) {
+		return m->size - 1;
+	}
+	if (nb < m->size) {
 		j = 0;
 		dictkv *kv = (dictkv *)m->table[i];
 		if (kv) {
@@ -127,10 +128,10 @@ SDB_API void dict_stats(dict *m) {
 				kv++;
 			}
 		}
-		printf ("%d\n", j);
+		return j;
 	}
+	return 0;
 }
-#endif
 
 SDB_API dictkv *dict_getr(dict *m, dicti k) {
 	if (!m->size) {

--- a/src/dict.h
+++ b/src/dict.h
@@ -1,6 +1,5 @@
 
 #define MHTSZ 32
-#define MHTNO 0
 
 typedef ut64 dicti;
 
@@ -8,13 +7,6 @@ typedef struct {
 	dicti k;
 	dicti v;
 	void *u;
-#if 0
-	// unaligned
-	// on 32bits
-	void *pad;
-	// on 64bits
-	void *pad;
-#endif
 } dictkv;
 
 // 4 + 4 + 4 = 12 .. missing 4 more
@@ -26,7 +18,7 @@ typedef void (*dict_freecb)(void *);
 typedef int (*dictkv_cb)(dictkv *, void *);
 
 typedef struct {
-	void **table; //[MHTSZ];
+	void **table;
 	dict_freecb f;
 	ut32 size;
 } dict;
@@ -37,7 +29,7 @@ SDB_API dict *dict_new(ut32 size, dict_freecb f);
 SDB_API void dict_free(dict*);
 SDB_API bool dict_init(dict *m, ut32, dict_freecb f);
 SDB_API void dict_fini(dict *m);
-SDB_API ut32 dict_stats(dict *m, int nb);
+SDB_API ut32 dict_stats(dict *m, ut32 nb);
 SDB_API dicti dict_hash(const char *s);
 SDB_API bool dict_set(dict *m, dicti k, dicti v, void *u);
 SDB_API dictkv *dict_getr(dict *m, dicti k);

--- a/src/dict.h
+++ b/src/dict.h
@@ -37,7 +37,7 @@ SDB_API dict *dict_new(ut32 size, dict_freecb f);
 SDB_API void dict_free(dict*);
 SDB_API bool dict_init(dict *m, ut32, dict_freecb f);
 SDB_API void dict_fini(dict *m);
-// SDB_API void dict_stats(dict *m);
+SDB_API ut32 dict_stats(dict *m, int nb);
 SDB_API dicti dict_hash(const char *s);
 SDB_API bool dict_set(dict *m, dicti k, dicti v, void *u);
 SDB_API dictkv *dict_getr(dict *m, dicti k);

--- a/src/dict.h
+++ b/src/dict.h
@@ -37,7 +37,7 @@ SDB_API dict *dict_new(ut32 size, dict_freecb f);
 SDB_API void dict_free(dict*);
 SDB_API bool dict_init(dict *m, ut32, dict_freecb f);
 SDB_API void dict_fini(dict *m);
-SDB_API void dict_stats(dict *m);
+// SDB_API void dict_stats(dict *m);
 SDB_API dicti dict_hash(const char *s);
 SDB_API bool dict_set(dict *m, dicti k, dicti v, void *u);
 SDB_API dictkv *dict_getr(dict *m, dicti k);

--- a/src/disk.c
+++ b/src/disk.c
@@ -33,7 +33,6 @@ static wchar_t *r_utf8_to_utf16_l (const char *cstring, int len) {
 static bool r_sys_mkdir(const char *path) {
 	LPTSTR path_ = r_sys_conv_utf8_to_utf16 (path);
 	bool ret = CreateDirectory (path_, NULL);
-
 	free (path_);
 	return ret;
 }
@@ -50,8 +49,7 @@ static bool r_sys_mkdir(const char *path) {
 #define r_sys_mkdir_failed() (errno != EEXIST)
 #endif
 
-static inline int r_sys_mkdirp(char *dir) {
-	int ret = 1;
+static inline bool mkdirp(char *dir) {
 	const char slash = DIRSEP;
 	char *path = dir;
 	char *ptr = path;
@@ -67,14 +65,14 @@ static inline int r_sys_mkdirp(char *dir) {
 	while ((ptr = strchr (ptr, slash))) {
 		*ptr = 0;
 		if (!r_sys_mkdir (path) && r_sys_mkdir_failed ()) {
-			// eprintf ("r_sys_mkdirp: fail '%s' of '%s'\n", path, dir);
+			// eprintf ("cannot make directory r_sys_mkdirp: fail '%s' of '%s'\n", path, dir);
 			*ptr = slash;
-			return 0;
+			return false;
 		}
 		*ptr = slash;
 		ptr++;
 	}
-	return ret;
+	return true;
 }
 
 SDB_API bool sdb_disk_create(Sdb* s) {
@@ -95,7 +93,7 @@ SDB_API bool sdb_disk_create(Sdb* s) {
 		return false;
 	}
 	memcpy (str, dir, nlen + 1);
-	r_sys_mkdirp (str);
+	mkdirp (str);
 	memcpy (str + nlen, ".tmp", 5);
 	if (s->fdump != -1) {
 		close (s->fdump);

--- a/src/json.c
+++ b/src/json.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2012-2021 - pancake */
+/* sdb - MIT - Copyright 2012-2022 - pancake */
 
 #include <stdarg.h>
 #include "sdb.h"

--- a/src/json/path.c
+++ b/src/json/path.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2012-2021 - pancake */
+/* sdb - MIT - Copyright 2012-2022 - pancake */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -125,8 +125,7 @@ SDB_IPI Rangstr json_find (const char *s, Rangstr *rs) {
 	if (len > RESFIXSZ) {
 		res = (RangstrType *)calloc (len + 1, sizeof (RangstrType));
 		if (!res) {
-			eprintf ("Cannot allocate %d byte%s\n",
-				len + 1, (len > 1)? "s": "");
+			// eprintf ("Cannot allocate %d byte%s\n", len + 1, (len > 1)? "s": "");
 			return rangstr_null ();
 		}
 	}

--- a/src/ls.c
+++ b/src/ls.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2007-2021 - pancake, alvaro */
+/* sdb - MIT - Copyright 2007-2022 - pancake, alvaro */
 
 #include <string.h>
 #include "ls.h"

--- a/src/query.c
+++ b/src/query.c
@@ -159,7 +159,8 @@ static void walk_namespace(StrBuf *sb, char *root, int left, char *p, SdbNs *ns,
 
 SDB_API char *sdb_querys(Sdb *r, char *buf, size_t len, const char *_cmd) {
 	bool bufset = false;
-	int i, d, ok, w, alength, is_ref = 0, encode = 0;
+	bool is_ref = false;
+	int i, d, ok, w, alength, encode = 0;
 	const char *p, *q, *val = NULL;
 	char *eq, *tmp, *json, *next, *quot, *slash, *cmd = NULL;
 	char *newcmd = NULL, *original_cmd = NULL;
@@ -201,7 +202,7 @@ repeat:
 	p = cmd;
 	eq = NULL;
 	encode = 0;
-	is_ref = 0;
+	is_ref = false;
 	quot = NULL;
 	json = NULL;
 	if (*p == '#') {
@@ -233,11 +234,13 @@ repeat:
 			if (next) *next = 0;
 			val = sdb_const_get (s, eq + 1, 0);
 			if (!val) {
-				eprintf ("No value for '%s'\n", eq + 1);
+				// eprintf ("No value for '%s'\n", eq + 1);
 				goto fail;
 			}
-			if (next) *next = ';';
-			is_ref = 1; // protect readonly buffer from being processed
+			if (next) {
+				*next = ';';
+			}
+			is_ref = true; // protect readonly buffer from being processed
 		} else {
 			val = eq;
 		}
@@ -248,7 +251,6 @@ repeat:
 	if (!is_ref) {
 		next = (char *)strchr (val? val: cmd, ';');
 	}
-	//if (!val) val = eq;
 	if (!is_ref && val && *val == '"') {
 		val++;
 		// TODO: escape \" too
@@ -262,7 +264,7 @@ next_quote:
 			}
 			*quot++ = 0; // crash on read only mem!!
 		} else {
-			eprintf ("Missing quote\n");
+		//	eprintf ("Missing quote\n");
 			*eq++ = 0;
 			out = strbuf_free (out);
 			goto fail;
@@ -279,19 +281,18 @@ next_quote:
 		*slash = 0;
 		s = sdb_ns (s, cmd, eq? 1: 0);
 		if (!s) {
-			eprintf ("Cant find namespace %s\n", cmd);
+			// eprintf ("Cant find namespace %s\n", cmd);
 			out = strbuf_free (out);
 			goto fail;
 		}
 		cmd = slash + 1;
 		slash = strchr (cmd, '/');
 	}
-	if (*cmd=='?') {
+	if (*cmd == '?') {
 		const char *val = sdb_const_get (s, cmd+1, 0);
 		const char *type = sdb_type (val);
 		out_concat (type);
-	} else
-	if (*cmd == '*') {
+	} else if (*cmd == '*') {
 		if (!strcmp (cmd, "***")) {
 			char root[1024]; // limit namespace length?
 			SdbListIter *it;
@@ -304,7 +305,7 @@ next_quote:
 						sizeof (root) - name_len,
 						root + name_len, ns, encode);
 				} else {
-					eprintf ("TODO: Namespace too long\n");
+					// eprintf ("TODO: Namespace too long\n");
 				}
 			}
 			goto fail;
@@ -333,7 +334,7 @@ next_quote:
 	if (*cmd == '[') {
 		char *tp = strchr (cmd, ']');
 		if (!tp) {
-			eprintf ("Missing ']'.\n");
+			// eprintf ("Missing ']'.\n");
 			goto fail;
 		}
 		*tp++ = 0;
@@ -351,12 +352,11 @@ next_quote:
 	if (*cmd == '.') {
 		if (s->options & SDB_OPTION_FS) {
 			if (!sdb_query_file (s, cmd + 1)) {
-				eprintf ("sdb: cannot open '%s'\n", cmd+1);
+				// eprintf ("sdb: cannot open '%s'\n", cmd+1);
 				goto fail;
 			}
-		} else {
-			eprintf ("sdb: filesystem access disabled in config\n");
 		}
+		// else eprintf ("sdb: filesystem access disabled in config\n");
 	} else if (*cmd == '~') { // delete
 		if (cmd[1] == '~') { // grep
 			SdbKv *kv;
@@ -386,7 +386,7 @@ next_quote:
 		if (cmd[1]=='[') {
 			const char *eb = strchr (cmd, ']');
 			if (!eb) {
-				eprintf ("Missing ']'.\n");
+				// eprintf ("Missing ']'.\n");
 				goto fail;
 			}
 			int idx = sdb_atoi (cmd + 2);
@@ -633,7 +633,7 @@ next_quote:
 						if (cmd[1]=='-') {
 							sdb_array_remove (s, p, cmd+2, 0);
 						} else {
-							eprintf ("TODO: [b]foo -> get index of b key inside foo array\n");
+							// eprintf ("TODO: [b]foo -> get index of b key inside foo array\n");
 						//	sdb_array_dels (s, p, cmd+1, 0);
 						}
 					} else if (i<0) {
@@ -835,9 +835,10 @@ fail:
 	return res;
 }
 
-SDB_API int sdb_query(Sdb *s, const char *cmd) {
+// TODO: should return a string instead, the must_save can be moved outside
+SDB_API bool sdb_query(Sdb *s, const char *cmd) {
 	char buf[128];
-	int must_save = ((*cmd == '~') || strchr (cmd, '='));
+	bool must_save = ((*cmd == '~') || strchr (cmd, '='));
 	char *out = sdb_querys (s, buf, sizeof (buf) - 1, cmd);
 	if (out) {
 		if (*out) {

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -432,7 +432,7 @@ SDB_API int sdb_open(Sdb *s, const char *file) {
 	s->last = 0LL;
 	if (s->fd != -1 && fstat (s->fd, &st) != -1) {
 		if ((S_IFREG & st.st_mode) != S_IFREG) {
-			eprintf ("Database must be a file\n");
+			// eprintf ("Database must be a file\n");
 			close (s->fd);
 			s->fd = -1;
 			return -1;

--- a/src/sdb.h
+++ b/src/sdb.h
@@ -154,7 +154,7 @@ SDB_API SdbList *sdb_foreach_list(Sdb* s, bool sorted);
 SDB_API SdbList *sdb_foreach_list_filter(Sdb* s, SdbForeachCallback filter, bool sorted);
 SDB_API SdbList *sdb_foreach_match(Sdb* s, const char *expr, bool sorted);
 
-SDB_API int sdb_query(Sdb* s, const char *cmd);
+SDB_API bool sdb_query(Sdb* s, const char *cmd);
 SDB_API int sdb_queryf(Sdb* s, const char *fmt, ...);
 SDB_API int sdb_query_lines(Sdb *s, const char *cmd);
 SDB_API char *sdb_querys(Sdb* s, char *buf, size_t len, const char *cmd);

--- a/src/util.c
+++ b/src/util.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2011-2021 - pancake */
+/* sdb - MIT - Copyright 2011-2022 - pancake */
 
 #include "sdb.h"
 

--- a/test/unit/test_dict.c
+++ b/test/unit/test_dict.c
@@ -8,22 +8,25 @@ int main() {
 	dict_set (&m, 0x200, 2, NULL);
 	dict_set (&m, 0x300, 3, NULL);
 	dict_set (&m, 0x400, 4, NULL);
-	printf ("%d %d\n", (int)dict_get(&m, 0x100), (int)dict_get(&m, 0x200));
-	printf ("%d %d\n", (int)dict_get(&m, 0x300), (int)dict_get(&m, 0x400));
+	printf ("%d %d\n", (int)dict_get (&m, 0x100), (int)dict_get (&m, 0x200));
+	printf ("%d %d\n", (int)dict_get (&m, 0x300), (int)dict_get (&m, 0x400));
 	if ((int)dict_get (&m, 0x100) != 1) {
 		return 1;
 	}
-	if ((int)dict_get(&m, 0x200) != 2) {
+	if ((int)dict_get (&m, 0x200) != 2) {
 		return 1;
 	}
-	if ((int)dict_get(&m, 0x300) != 3) {
+	if ((int)dict_get (&m, 0x300) != 3) {
 		return 1;
 	}
-	if ((int)dict_get(&m, 0x400) != 4) {
+	if ((int)dict_get (&m, 0x400) != 4) {
 		return 1;
 	}
 
-	dict_stats (&m);
+	int buckets = dict_stats (&m, -1);
+	for (i = 0; i < buckets; i++) {
+		printf ("%d: %d\n", i, dict_stats (&m, i));
+	}
 #if 0
 	dict_set(&m, dict_hash("username"), 1024, NULL);
 	dict_set(&m, 32, 212, strdup("test"));

--- a/test/unit/test_dict.c
+++ b/test/unit/test_dict.c
@@ -1,4 +1,3 @@
-// #include "minunit.h"
 #include <sdb.h>
 
 int main() {
@@ -24,6 +23,7 @@ int main() {
 	}
 
 	int buckets = dict_stats (&m, -1);
+	int i;
 	for (i = 0; i < buckets; i++) {
 		printf ("%d: %d\n", i, dict_stats (&m, i));
 	}


### PR DESCRIPTION
* fputs(stdout) is still pending to be removed, but this requires breaking API and ABI

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
