### PR TITLE
Fix AIX support

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -28,10 +28,18 @@ INSTALL_MAN=$(INSTALL) -m 444
 INSTALL_LIB=$(INSTALL) -c
 endif
 
-# link time optimization
-#CFLAGS_STD=-std=gnu99 -D_XOPEN_SOURCE=700 -D_POSIX_C_SOURCE=200809L -flto -O2
+OS=$(shell uname)
+OSTYPE?=$(shell uname -s)
+ARCH?=$(shell uname -m)
 
-CFLAGS_STD=-std=gnu99 -D_XOPEN_SOURCE=700 -D_POSIX_C_SOURCE=200809L
+# link time optimization
+#CFLAGS_STD=-std=gnu99 -flto -O2
+
+CFLAGS_STD=-std=gnu99
+ifeq (,$(findstring AIX,${OSTYPE}))
+CFLAGS_STD+=-D_XOPEN_SOURCE=700 -D_POSIX_C_SOURCE=200809L
+endif
+
 #CFLAGS+=-Wno-initializer-overrides
 CFLAGS:=${CFLAGS_STD} $(CFLAGS)
 
@@ -53,9 +61,6 @@ HAVE_VALA=$(shell valac --version 2> /dev/null)
 # This is hacky
 HOST_CC?=gcc
 RANLIB?=ranlib
-OS=$(shell uname)
-OSTYPE?=$(shell uname -s)
-ARCH?=$(shell uname -m)
 
 AR?=ar
 CC?=gcc

--- a/include/sdb/types.h
+++ b/include/sdb/types.h
@@ -42,6 +42,10 @@ extern "C" {
 #define __MINGW__ 1
 #endif
 
+#ifndef INT32_MAX
+#define INT32_MAX (0x7fffffff)
+#endif
+
 #if defined __WIN32__ || __MINGW__ > 0 || R2__WINDOWS__ || __WINDOWS__ > 0 || _MSC_VER > 0
 #define __SDB_WINDOWS__ 1
 #undef DIRSEP


### PR DESCRIPTION
- If _XOPEN_SOURCE macro is defined, SIZE_MAX disappears on AIX.
  So, disable it.
- INT32_MAX macro doesn't exist, so patch it up.

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
