### PR TITLE
Fix symbol conflicts with libmagic

### DIFF
--- a/include/sdb/buffer.h
+++ b/include/sdb/buffer.h
@@ -21,7 +21,7 @@ typedef struct buffer {
 #define BUFFER_INSIZE 8192
 #define BUFFER_OUTSIZE 8192
 
-void buffer_init(buffer *,BufferOp,int,char *,unsigned int);
+void buffer_initialize(buffer *,BufferOp,int,char *,unsigned int);
 
 int buffer_flush(buffer *);
 int buffer_put(buffer *,const char *,unsigned int);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2,7 +2,7 @@
 
 #include "sdb/buffer.h"
 
-void buffer_init(buffer *s, BufferOp op, int fd, char *buf, ut32 len) {
+void buffer_initialize(buffer *s, BufferOp op, int fd, char *buf, ut32 len) {
 	s->x = buf;
 	s->fd = fd;
 	s->op = op;

--- a/src/cdb_make.c
+++ b/src/cdb_make.c
@@ -42,7 +42,7 @@ int cdb_make_start(struct cdb_make *c, int fd) {
 	c->numentries = 0;
 	c->fd = fd;
 	c->pos = sizeof (c->final);
-	buffer_init (&c->b, (BufferOp)write, fd, c->bspace, sizeof (c->bspace));
+	buffer_initialize (&c->b, (BufferOp)write, fd, c->bspace, sizeof (c->bspace));
 	c->memsize = 1;
 	for (i = 0; i < 256; i++) {
 		c->count[i] = 0;


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

libmagic defines the buffer_init symbol, so I've renamed it to buffer_initialize. Honestly, neither libmagic nor sdb should be using this symbol name since it's so generic. So perhaps we could rename all of these `buffer_` methods to `sdb_buffer_` if that works.