### PR TITLE
Fix mcsdbd bulk read bounds

### DIFF
--- a/memcache/main.c
+++ b/memcache/main.c
@@ -114,6 +114,12 @@ static int mcsdb_client_state(McSdbClient *c) {
 			c->idx = 0;
 		r = 0;
 		rlen = c->len-c->idx;
+		if (rlen > MCSDB_MAX_BUFFER - 1 - c->idx) {
+			*c->buf = 0;
+			c->idx = 0;
+			c->len = 0;
+			return 0;
+		}
 		if (rlen>0 && c->len>0) {
 			r = read (c->fd, c->buf+c->idx, rlen);
 			if (r==-1) {
@@ -133,7 +139,7 @@ static int mcsdb_client_state(McSdbClient *c) {
 			}// else eprintf ("Invalid %d read wtf\n", r);
 		} 
 		c->idx += r;
-		c->buf[c->idx+1] = 0;
+		c->buf[c->idx] = 0;
 		if (c->idx == c->len) {
 		//	printf ("END OF MODE 1 ***/*/*///*/* ((%s))\n", c->buf);
 			return 1;


### PR DESCRIPTION
### Motivation
- Prevent a remote, attacker-controlled length from driving `read()` past the fixed client buffer and corrupting heap memory.
- Ensure the in-memory client buffer is NUL-terminated at the correct index to avoid a one-byte past-the-end write.
- Harden the mcsdbd state machine so local state cannot be exploited even if protocol-level checks are bypassed.

### Description
- Add a local bounds check in `mcsdb_client_state` (in `memcache/main.c`) that verifies `rlen` does not exceed the remaining space in `c->buf` and aborts the read if it would overflow.
- Change the NUL terminator write from `c->buf[c->idx+1]` to `c->buf[c->idx]` to avoid writing one byte past the valid buffer region.
- Keep existing protocol-level guard that rejects `bytes > (MCSDB_MAX_BUFFER - 2)` in `memcache/protocol.c` as defense-in-depth while adding a local runtime check.

### Testing
- Ran `git diff --check` to validate the working tree formatting and diffs, which passed. 
- Built the main library with `make -C src`, which completed successfully. 
- Attempted to build the memcache helper with `make -C memcache`, which failed during `cmds.h` generation due to an unrelated host-link issue where the helper links `../src/util.c` and the symbol `sdb_strdup` was unresolved; this build failure is not caused by the bounds fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297354f5648331b66ef0681729044d)